### PR TITLE
Change wording around word boundary spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -403,18 +403,26 @@ API for word boundary matching.
         boundary in <em>text</em> before <em>range</em>.
     4. Using locale <em>locale</em>, let <em>right bound</em> be the first word
         boundary in <em>text</em> after <em>range</em>.
-        <div class="note">Word boundary matching is one of the security
-        mitigations for this feature. A word boundary is as defined in the
-        <a href="http://www.unicode.org/reports/tr29/#Word_Boundaries">Unicode
-        text segmentation annex</a>. The
-        <a href="http://www.unicode.org/reports/tr29/#Default_Word_Boundaries">
-        Default Word Boundary Specification</a> defines a default set of what
-        constitutes a word boundary, but as the specification mentions, a
-        language-specific word boundary library should be used where possible
-        based on the <em>locale</em>, such as the ICU library. For dictionary
-        based word bounding in languages with a small number of characters
-        (<100) the dictionary must not contain a large proportion of the
-        individual characters (<20%).
+        <div class="note">
+          <p>
+            Limiting matching to word boundaries is one of the mitigations to
+            limit cross-origin information leakage. A word boundary is as
+            defined in the <a
+            href="http://www.unicode.org/reports/tr29/#Word_Boundaries">Unicode
+            text segmentation annex</a>. The <a
+            href="http://www.unicode.org/reports/tr29/#Default_Word_Boundaries">
+            Default Word Boundary Specification</a> defines a default set of what
+            constitutes a word boundary, but as the specification mentions, a
+            more sophisticated algorithm should be used based on the
+            <em>locale</em>.
+          </p>
+          <p>
+            Dictionary-based word bounding should take specific care in
+            locales without a word-separating character (e.g. space). In
+            those cases, and where the alphabet contains fewer than 100
+            characters, the dictionary must not contain more than 20% of the
+            alphabet as valid, one-letter words.
+          </p>
         </div>
     5. If <em>left bound</em> immediately precedes <em>range</em> and <em>right
         bound</em> immediately follows <em>range</em>, then return

--- a/index.html
+++ b/index.html
@@ -1403,7 +1403,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-07">7 October 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-08">8 October 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1881,15 +1881,19 @@ boundary in <em>text</em> before <em>range</em>.</p>
       <li data-md>
        <p>Using locale <em>locale</em>, let <em>right bound</em> be the first word
 boundary in <em>text</em> after <em>range</em>.</p>
-       <div class="note" role="note">Word boundary matching is one of the security
-mitigations for this feature. A word boundary is as defined in the <a href="http://www.unicode.org/reports/tr29/#Word_Boundaries">Unicode
-text segmentation annex</a>. The <a href="http://www.unicode.org/reports/tr29/#Default_Word_Boundaries"> Default Word Boundary Specification</a> defines a default set of what
-constitutes a word boundary, but as the specification mentions, a
-language-specific word boundary library should be used where possible
-based on the <em>locale</em>, such as the ICU library. For dictionary
-based word bounding in languages with a small number of characters
-(&lt;100) the dictionary must not contain a large proportion of the
-individual characters (&lt;20%). </div>
+       <div class="note" role="note">
+        <p> Limiting matching to word boundaries is one of the mitigations to
+    limit cross-origin information leakage. A word boundary is as
+    defined in the <a href="http://www.unicode.org/reports/tr29/#Word_Boundaries">Unicode
+    text segmentation annex</a>. The <a href="http://www.unicode.org/reports/tr29/#Default_Word_Boundaries"> Default Word Boundary Specification</a> defines a default set of what
+    constitutes a word boundary, but as the specification mentions, a
+    more sophisticated algorithm should be used based on the <em>locale</em>. </p>
+        <p> Dictionary-based word bounding should take specific care in
+    locales without a word-separating character (e.g. space). In
+    those cases, and where the alphabet contains fewer than 100
+    characters, the dictionary must not contain more than 20% of the
+    alphabet as valid, one-letter words. </p>
+       </div>
       <li data-md>
        <p>If <em>left bound</em> immediately precedes <em>range</em> and <em>right
 bound</em> immediately follows <em>range</em>, then return <em>range</em>.</p>


### PR DESCRIPTION
Reworded the section around word boundary computation and its details around languages without a word separating character (space).