### PR TITLE
Add note to spec about directive appearing in fragment

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -123,6 +123,16 @@ by the UA to process the resource. It is initially null
 Let the <em>fragment-directive delimiter</em> be the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).
 
+<div class="note">
+  The fragment-directive is part of the URL fragment. This means it must always
+  appear after a U+0023 (#) code point in a URL. 
+</div>
+
+<div class="example">
+  To add a fragment-directive to a URL like https://example.com, a fragment
+  must first be appended to the URL: https://example.com#:~:text=foo.
+</div>
+
 Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser">
 basic URL parser</a> steps to parse fragment directives in a URL:
 

--- a/index.bs
+++ b/index.bs
@@ -452,3 +452,156 @@ interface Location {
     readonly attribute FragmentDirective fragmentDirective;
 };
 </pre>
+
+# Generating Text Fragment Directives # {#generating-text-fragment-directives}
+
+<div class='note'>
+  This section is non-normative.
+</div>
+
+This section contains recommendations for UAs automatically generating URLs
+with text fragment directives. These recommendations aren't normative but are
+provided to ensure generated URLs result in maximally stable and usable URLs.
+
+## Prefer Exact Matching To Range-based
+
+The match text can be provided either as an exact string "text=foo%20bar%20baz"
+or as a range "text=foo,bar".
+
+UAs should prefer to specify the entire string where practical. This ensures
+that if the destination page is removed or changed, the intended destination can
+still be derived from the URL itself.
+
+<div class='example'>
+  Suppose we wish to craft a URL to
+  https://en.wikipedia.org/wiki/History_of_computing quoting the sentence:
+
+  <pre>
+    The first recorded idea of using digital electronics for computing was the
+    1931 paper "The Use of Thyratrons for High Speed Automatic Counting of
+    Physical Phenomena" by C. E. Wynn-Williams.
+  </pre>
+
+  We could create a range-based match like so:
+
+  <a href="https://en.wikipedia.org/wiki/History_of_computing#:~:text=The%20first%20recorded,Williams">
+  https://en.wikipedia.org/wiki/History_of_computing#:~:text=The%20first%20recorded,Williams</a>
+
+  Or we could encode the entire sentence using an exact match term:
+
+  <a href="https://en.wikipedia.org/wiki/History_of_computing#:~:text=The%20first%20recorded%20idea%20of%20using%20digital%20electronics%20for%20computing%20was%20the%201931%20paper%20%22The%20Use%20of%20Thyratrons%20for%20High%20Speed%20Automatic%20Counting%20of%20Physical%20Phenomena%22%20by%20C.%20E.%20Wynn-Williams">
+  https://en.wikipedia.org/wiki/History_of_computing#:~:text=The%20first%20recorded%20idea%20of%20using%20digital%20electronics%20for%20computing%20was%20the%201931%20paper%20%22The%20Use%20of%20Thyratrons%20for%20High%20Speed%20Automatic%20Counting%20of%20Physical%20Phenomena%22%20by%20C.%20E.%20Wynn-Williams</a>
+
+  The range-based match is less stable, meaning that if the page is changed to
+  include another instance of "The first recorded" somewhere earlier in the
+  page, the link will now target an unintended text snippet.
+
+  The range-based match is also less useful semantically. If the page is
+  changed to remove the sentence, the user won't know what the intended
+  target was. In the exact match case, the user can read, or the UA can
+  surface, the text that was being searched for but not found.
+</div>
+
+Range-based matches can be helpful when the quoted text is excessively long
+and encoding the entire string would produce an unwieldly URL.
+
+It is recommended that text snippets shorter than 300 characters always be
+encoded using an exact match. Above this limit, the UA should encode the string
+as a range-based match.
+
+<div class='note'>
+  TODO:  Can we determine the above limit in some more objective way?
+</div>
+
+## Use Context Only When Necessary
+
+Context terms allow the text fragment directive to disambiguate text snippets
+on a page. However, their use can make the URL more brittle in some cases.
+Often, the desired string will at an element boundary. The context will
+therefore exist in an adjacent element. Changes to the page structure could
+invalidate the text fragment directive since the context and match text may no
+longer appear to be adjacent.
+
+<div class='example'>
+  Suppose we wish to craft a URL for the following text:
+
+  <pre>
+        &lt;div class="section"&gt;HEADER&lt;/div&gt;
+        &lt;div class="content"&gt;Text to quote&lt;/div&gt;
+  </pre>
+
+  We could craft a the text fragment directive as follows:
+
+  <pre>
+    text=HEADER-,Text%20to%20quote
+  </pre>
+
+  However, suppose the page changes to add a "[edit]" link beside all section
+  headers. This would now break the URL.
+</div>
+
+Where a text snippet is long enough and unique, a UA should prefer to avoid
+adding superfluous context terms.
+
+It is recommended that context should be used only if one of the following is
+true:
+<ul>
+  <li>The UA determines the quoted text is ambiguous</li>
+  <li>The quoted text contains 3 or fewer words</li>
+</ul>
+
+<div class="note">
+  TODO: Determine the numeric limit above in a more objective way
+</div>
+
+## Determine If Fragment Id Is Needed
+
+When the UA navigates to a URL containing a text fragment directive, it will
+fallback to scrolling into view a regular element-id based fragment if it
+exists and the text fragment isn't found.
+
+This can be useful to provide a fallback, in case the text in the document
+changes, invalidating the text fragment directive.
+
+<div class='example'>
+  Suppose we wish to craft a URL to
+  https://en.wikipedia.org/wiki/History_of_computing quoting the sentence:
+
+  <pre>
+    The earliest known tool for use in computation is the Sumerian abacus
+  </pre>
+
+  By specifying the section that the text appears in, we ensure that, if the
+  text is changed or removed, the user will still be pointed to the relevant
+  section:
+
+  <a href="https://en.wikipedia.org/wiki/History_of_computing#Early_computation:~:text=The%20earliest%20known%20tool%20for%20use%20in%20computation%20is%20the%20Sumerian%20abacus">
+  https://en.wikipedia.org/wiki/History_of_computing#Early_computation:~:text=The%20earliest%20known%20tool%20for%20use%20in%20computation%20is%20the%20Sumerian%20abacus</a>
+</div>
+
+However, UAs should take care that the fallback element-id fragment is the
+correct one:
+
+<div class='example'>
+  Suppose the user navigates to
+  https://en.wikipedia.org/wiki/History_of_computing#Early_computation. They
+  now scroll down to the Symbolic Computations section. There, they select a
+  text snippet and choose to create a URL to it:
+
+  <pre>
+    By the late 1960s, computer systems could perform symbolic algebraic
+    manipulations
+  </pre>
+
+  The UA should note that, even though the current URL of the page is:
+  https://en.wikipedia.org/wiki/History_of_computing#Early_computation, using
+  #Early_computation as a fallback is inappropriate. If the above sentence is
+  changed or removed, the page will load in the #Early_computation section
+  which could be quite confusing to the user.
+
+  If the UA cannot reliably determine an appropriate fragment to fallback to,
+  it should remove the fragment id from the URL:
+
+  <a href="https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations">
+  https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations</a>
+</div>

--- a/index.html
+++ b/index.html
@@ -1535,6 +1535,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        </ol>
       <li><a href="#feature-detectability"><span class="secno">2.4</span> <span class="content">Feature Detectability</span></a>
      </ol>
+    <li>
+     <a href="#generating-text-fragment-directives"><span class="secno">3</span> <span class="content">Generating Text Fragment Directives</span></a>
+     <ol class="toc">
+      <li><a href="#prefer-exact-matching-to-range-based"><span class="secno">3.1</span> <span class="content">Prefer Exact Matching To Range-based</span></a>
+      <li><a href="#use-context-only-when-necessary"><span class="secno">3.2</span> <span class="content">Use Context Only When Necessary</span></a>
+      <li><a href="#determine-if-fragment-id-is-needed"><span class="secno">3.3</span> <span class="content">Determine If Fragment Id Is Needed</span></a>
+     </ol>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
@@ -1970,6 +1977,104 @@ Location Interface</a> to include a fragmentDirective property:</p>
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-location-fragmentdirective"></a></dfn>;
 };
 </pre>
+   <h2 class="heading settled" data-level="3" id="generating-text-fragment-directives"><span class="secno">3. </span><span class="content">Generating Text Fragment Directives</span><a class="self-link" href="#generating-text-fragment-directives"></a></h2>
+   <div class="note" role="note"> This section is non-normative. </div>
+   <p>This section contains recommendations for UAs automatically generating URLs
+with text fragment directives. These recommendations aren’t normative but are
+provided to ensure generated URLs result in maximally stable and usable URLs.</p>
+   <h3 class="heading settled" data-level="3.1" id="prefer-exact-matching-to-range-based"><span class="secno">3.1. </span><span class="content">Prefer Exact Matching To Range-based</span><a class="self-link" href="#prefer-exact-matching-to-range-based"></a></h3>
+   <p>The match text can be provided either as an exact string "text=foo%20bar%20baz"
+or as a range "text=foo,bar".</p>
+   <p>UAs should prefer to specify the entire string where practical. This ensures
+that if the destination page is removed or changed, the intended destination can
+still be derived from the URL itself.</p>
+   <div class="example" id="example-53e82e58">
+    <a class="self-link" href="#example-53e82e58"></a> Suppose we wish to craft a URL to
+  https://en.wikipedia.org/wiki/History_of_computing quoting the sentence: 
+<pre>The first recorded idea of using digital electronics for computing was the
+1931 paper "The Use of Thyratrons for High Speed Automatic Counting of
+Physical Phenomena" by C. E. Wynn-Williams.
+</pre>
+    <p>We could create a range-based match like so:</p>
+    <p><a href="https://en.wikipedia.org/wiki/History_of_computing#:~:text=The%20first%20recorded,Williams"> https://en.wikipedia.org/wiki/History_of_computing#:~:text=The%20first%20recorded,Williams</a></p>
+    <p>Or we could encode the entire sentence using an exact match term:</p>
+    <p><a href="https://en.wikipedia.org/wiki/History_of_computing#:~:text=The%20first%20recorded%20idea%20of%20using%20digital%20electronics%20for%20computing%20was%20the%201931%20paper%20%22The%20Use%20of%20Thyratrons%20for%20High%20Speed%20Automatic%20Counting%20of%20Physical%20Phenomena%22%20by%20C.%20E.%20Wynn-Williams"> https://en.wikipedia.org/wiki/History_of_computing#:~:text=The%20first%20recorded%20idea%20of%20using%20digital%20electronics%20for%20computing%20was%20the%201931%20paper%20%22The%20Use%20of%20Thyratrons%20for%20High%20Speed%20Automatic%20Counting%20of%20Physical%20Phenomena%22%20by%20C.%20E.%20Wynn-Williams</a></p>
+    <p>The range-based match is less stable, meaning that if the page is changed to
+  include another instance of "The first recorded" somewhere earlier in the
+  page, the link will now target an unintended text snippet.</p>
+    <p>The range-based match is also less useful semantically. If the page is
+  changed to remove the sentence, the user won’t know what the intended
+  target was. In the exact match case, the user can read, or the UA can
+  surface, the text that was being searched for but not found.</p>
+   </div>
+   <p>Range-based matches can be helpful when the quoted text is excessively long
+and encoding the entire string would produce an unwieldly URL.</p>
+   <p>It is recommended that text snippets shorter than 300 characters always be
+encoded using an exact match. Above this limit, the UA should encode the string
+as a range-based match.</p>
+   <div class="note" role="note"> TODO:  Can we determine the above limit in some more objective way? </div>
+   <h3 class="heading settled" data-level="3.2" id="use-context-only-when-necessary"><span class="secno">3.2. </span><span class="content">Use Context Only When Necessary</span><a class="self-link" href="#use-context-only-when-necessary"></a></h3>
+   <p>Context terms allow the text fragment directive to disambiguate text snippets
+on a page. However, their use can make the URL more brittle in some cases.
+Often, the desired string will at an element boundary. The context will
+therefore exist in an adjacent element. Changes to the page structure could
+invalidate the text fragment directive since the context and match text may no
+longer appear to be adjacent.</p>
+   <div class="example" id="example-d84dfa8a">
+    <a class="self-link" href="#example-d84dfa8a"></a> Suppose we wish to craft a URL for the following text: 
+<pre>&lt;div class="section">HEADER&lt;/div>
+&lt;div class="content">Text to quote&lt;/div>
+</pre>
+    <p>We could craft a the text fragment directive as follows:</p>
+<pre>text=HEADER-,Text%20to%20quote
+</pre>
+    <p>However, suppose the page changes to add a "[edit]" link beside all section
+  headers. This would now break the URL.</p>
+   </div>
+   <p>Where a text snippet is long enough and unique, a UA should prefer to avoid
+adding superfluous context terms.</p>
+   <p>It is recommended that context should be used only if one of the following is
+true:</p>
+   <ul>
+    <li>The UA determines the quoted text is ambiguous
+    <li>The quoted text contains 3 or fewer words
+   </ul>
+   <div class="note" role="note"> TODO: Determine the numeric limit above in a more objective way </div>
+   <h3 class="heading settled" data-level="3.3" id="determine-if-fragment-id-is-needed"><span class="secno">3.3. </span><span class="content">Determine If Fragment Id Is Needed</span><a class="self-link" href="#determine-if-fragment-id-is-needed"></a></h3>
+   <p>When the UA navigates to a URL containing a text fragment directive, it will
+fallback to scrolling into view a regular element-id based fragment if it
+exists and the text fragment isn’t found.</p>
+   <p>This can be useful to provide a fallback, in case the text in the document
+changes, invalidating the text fragment directive.</p>
+   <div class="example" id="example-5990805b">
+    <a class="self-link" href="#example-5990805b"></a> Suppose we wish to craft a URL to
+  https://en.wikipedia.org/wiki/History_of_computing quoting the sentence: 
+<pre>The earliest known tool for use in computation is the Sumerian abacus
+</pre>
+    <p>By specifying the section that the text appears in, we ensure that, if the
+  text is changed or removed, the user will still be pointed to the relevant
+  section:</p>
+    <p><a href="https://en.wikipedia.org/wiki/History_of_computing#Early_computation:~:text=The%20earliest%20known%20tool%20for%20use%20in%20computation%20is%20the%20Sumerian%20abacus"> https://en.wikipedia.org/wiki/History_of_computing#Early_computation:~:text=The%20earliest%20known%20tool%20for%20use%20in%20computation%20is%20the%20Sumerian%20abacus</a></p>
+   </div>
+   <p>However, UAs should take care that the fallback element-id fragment is the
+correct one:</p>
+   <div class="example" id="example-0ae51dec">
+    <a class="self-link" href="#example-0ae51dec"></a> Suppose the user navigates to
+  https://en.wikipedia.org/wiki/History_of_computing#Early_computation. They
+  now scroll down to the Symbolic Computations section. There, they select a
+  text snippet and choose to create a URL to it: 
+<pre>By the late 1960s, computer systems could perform symbolic algebraic
+manipulations
+</pre>
+    <p>The UA should note that, even though the current URL of the page is:
+  https://en.wikipedia.org/wiki/History_of_computing#Early_computation, using
+  #Early_computation as a fallback is inappropriate. If the above sentence is
+  changed or removed, the page will load in the #Early_computation section
+  which could be quite confusing to the user.</p>
+    <p>If the UA cannot reliably determine an appropriate fragment to fallback to,
+  it should remove the fragment id from the URL:</p>
+    <p><a href="https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations"> https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations</a></p>
+   </div>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 5edf8bee6cb6f00d270bf8e0fbb20d6ccc477cfd" name="generator">
+  <meta content="Bikeshed version 7e430f4a6cb4a7616872addf238a902c73553f9d" name="generator">
   <link href="wicg.github.io/ScrollToTextFragment/draftspec.html" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-09">9 October 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-10">10 October 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1624,6 +1624,10 @@ translation-hints or enabling accessibility features.</p>
 by the UA to process the resource. It is initially null </em></p>
    <p>Let the <em>fragment-directive delimiter</em> be the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
+   <div class="note" role="note"> The fragment-directive is part of the URL fragment. This means it must always
+  appear after a U+0023 (#) code point in a URL. </div>
+   <div class="example" id="example-8a44ecf3"><a class="self-link" href="#example-8a44ecf3"></a> To add a fragment-directive to a URL like https://example.com, a fragment
+  must first be appended to the URL: https://example.com#:~:text=foo. </div>
    <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse fragment directives in a URL:</p>
    <ul>
     <li data-md>


### PR DESCRIPTION
Add a note and example to clarify that the fragment-directive must always appear in the fragment
portion of the URL. i.e. To generate a text directive, a hash must be added to the URL if it doesn't contain an existing fragment.