### PR TITLE
Add formal grammar for text directives

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -217,12 +217,25 @@ Replace steps 7 and 8 of this algorithm with:
 11. Set <em>url's fragment-directive</em> to null.
 12. Set the <em>document's url</em> to be <em>url</em>.
 
-### Text directive grammar ### {#text-directive-grammer}
-A <dfn>valid text directive</dfn> is a sequence of characters that appears in
-the [=fragment directive=] that matches the production:
+### Fragment directive grammar ### {#fragment-directive-grammar}
+A <dfn>valid fragment directive</dfn> is a sequence of characters that appears
+in the [=fragment directive=] that matches the production:
+<dl>
+<code><dt><dfn>FragmentDirective</dfn> ::=</dt> <dd>[=TextDirective=] ("&" [=TextDirective=])*</dd></code>
+</dl>
+
+<div class="note">
+The [=FragmentDirective=] may contain multiple directives split by the "&"
+character. Currently this means we allow multiple text directives to enable
+multiple indicated strings in the page, but this also allows for future
+directive types to be added and combined.
+</div>
+
+A <dfn>valid text directive</dfn> is one such directive, that matches the
+production:
 
 <dl>
-<code><dt><dfn>TextDirective</dfn> ::=</dt> <dd>"text=" [=TextDirectiveParameters=] ("&text=" [=TextDirectiveParameters=])*</dd></code>
+<code><dt><dfn>TextDirective</dfn> ::=</dt> <dd>"text=" [=TextDirectiveParameters=]</dd></code>
 <code><dt><dfn>TextDirectiveParameters</dfn> ::=</dt> <dd>([=TextDirectivePrefix=] ",")? [=TextMatchString=] ("," [=TextMatchString=])? ("," [=TextDirectiveSuffix=])?</dd></code>
 <code><dt><dfn>TextDirectivePrefix</dfn> ::=</dt> <dd>[=TextMatchString=] "-"</dd></code>
 <code><dt><dfn>TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" [=TextMatchString=]</dd></code>

--- a/index.bs
+++ b/index.bs
@@ -421,3 +421,24 @@ API for word boundary matching.
         bound</em> immediately follows <em>range</em>, then return
         <em>range</em>.
 2. Return <em>null</em>.
+
+## Feature Detectability ## {#feature-detectability}
+
+For feature detectability, we propose adding a new FragmentDirective interface
+that is exposed via window.location.fragmentDirective if the UA supports the
+feature.
+
+<pre class='idl'>
+interface FragmentDirective {
+};
+</pre>
+
+We amend
+<a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface">The
+Location Interface</a> to include a fragmentDirective property:
+
+<pre class='idl'>
+interface Location {
+    readonly attribute FragmentDirective fragmentDirective;
+};
+</pre>

--- a/index.bs
+++ b/index.bs
@@ -41,8 +41,8 @@ the receiver loses the context of the page.
 
 <div class='note'>This section is non-normative</div>
 
-A text fragment is specified in the fragment directive (see
-[[#fragment-directive]]) with the following format:
+A [=valid text directive=] is specified in the fragment directive (see
+[[#the-fragment-directive]]) with the following format:
 <pre>
 #:~:text=[prefix-,]textStart[,textEnd][,-suffix]
           context  |-------match-----|  context
@@ -104,7 +104,7 @@ to "an example" in "this is an example text fragment", but not match to "an
 example" in "here is an example text".
 </div>
 
-## The Fragment Directive ## {#fragment-directive}
+## The Fragment Directive ## {#the-fragment-directive}
 To avoid compatibility issues with usage of existing URL fragments, this spec
 introduces the <em>fragment directive</em>. The fragment directive is a portion
 of the URL fragment delimited by the code sequence <code>:~:</code>. It is
@@ -127,8 +127,11 @@ A URL's fragment-directive is either null or an ASCII string holding data used
 by the UA to process the resource. It is initially null
 </em>
 
-Let the <em>fragment-directive delimiter</em> be the string ":~:", that is the
+The <dfn>fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).
+
+The <dfn>fragment directive</dfn> is the part of the URL fragment that follows
+the [=fragment directive delimiter=].
 
 <div class="note">
   The fragment-directive is part of the URL fragment. This means it must always
@@ -149,7 +152,7 @@ basic URL parser</a> steps to parse fragment directives in a URL:
         - If <em>c</em> is U+003A (:) and <em>remaining</em> begins with the two
             consecutive code points U+007E (~) and U+003A (:), set state to
             <em>fragment-directive state</em>. Increment <em>c</em> by the
-            length of the <em>fragment-directive delimiter</em> minus 1.
+            length of the [=fragment directive delimiter=] minus 1.
     - Step 3 (now step 4 after the above change) must begin with "Otherwise,"
   - In step 11 of this algorithm, add a new <em>fragment-directive state</em>
     case with the following steps:
@@ -167,8 +170,8 @@ basic URL parser</a> steps to parse fragment directives in a URL:
                 and append the result to <em>url’s fragment-directive</em>.
 
 <div class="note">
-  These changes make a URL's fragment end at the fragment directive delimiter.
-  The fragment-directive includes all characters that follow, but not including,
+  These changes make a URL's fragment end at the [=fragment directive delimiter=].
+  The [=fragment directive=] includes all characters that follow, but not including,
   the delimiter.
 </div>
 
@@ -213,6 +216,26 @@ Replace steps 7 and 8 of this algorithm with:
     web-exposed)
 11. Set <em>url's fragment-directive</em> to null.
 12. Set the <em>document's url</em> to be <em>url</em>.
+
+### Text directive grammar ### {#text-directive-grammer}
+A <dfn>valid text directive</dfn> is a sequence of characters that appears in
+the [=fragment directive=] that matches the production:
+
+<dl>
+<code><dt><dfn>TextDirective</dfn> ::=</dt> <dd>"text=" [=TextDirectiveParameters=] ("&text=" [=TextDirectiveParameters=])*</dd></code>
+<code><dt><dfn>TextDirectiveParameters</dfn> ::=</dt> <dd>([=TextDirectivePrefix=] ",")? [=TextMatchString=] ("," [=TextMatchString=])? ("," [=TextDirectiveSuffix=])?</dd></code>
+<code><dt><dfn>TextDirectivePrefix</dfn> ::=</dt> <dd>[=TextMatchString=] "-"</dd></code>
+<code><dt><dfn>TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" [=TextMatchString=]</dd></code>
+<code><dt><dfn>TextMatchString</dfn> ::=</dt> <dd>([=TextMatchChar=] | [=PercentEncodedChar=])+</dd></code>
+<code><dt><dfn>TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code>
+<div class = "note">
+A [=TextMatchChar=] may be any
+<a href="https://url.spec.whatwg.org/#url-code-points">URL code point</a> that
+is not explicitly used in the [=TextDirective=] syntax, that is "&", "-", and ",",
+which must be percent-encoded.
+</div>
+<code><dt><dfn>PercentEncodedChar</dfn> ::=</dt> <dd>"%" [a-zA-Z0-9]+</dd></code>
+</dl>
 
 ## Security and Privacy ## {#allow-text-fragment-directives}
 

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 86a39676f08870ba1210b97fe65ff62bd4e723c9" name="generator">
+  <meta content="Bikeshed version 98212c11613b78977e54b28cc53499f2ee83d388" name="generator">
   <link href="wicg.github.io/ScrollToTextFragment/draftspec.html" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-10">10 October 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-17">17 October 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1519,11 +1519,12 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#context-terms"><span class="secno">2.1.1</span> <span class="content">Context Terms</span></a>
        </ol>
       <li>
-       <a href="#fragment-directive"><span class="secno">2.2</span> <span class="content">The Fragment Directive</span></a>
+       <a href="#the-fragment-directive"><span class="secno">2.2</span> <span class="content">The Fragment Directive</span></a>
        <ol class="toc">
         <li><a href="#parsing-the-fragment-directive"><span class="secno">2.2.1</span> <span class="content">Parsing the fragment directive</span></a>
         <li><a href="#serializing-the-fragment-directive"><span class="secno">2.2.2</span> <span class="content">Serializing the fragment directive</span></a>
         <li><a href="#processing-the-fragment-directive"><span class="secno">2.2.3</span> <span class="content">Processing the fragment directive</span></a>
+        <li><a href="#text-directive-grammer"><span class="secno">2.2.4</span> <span class="content">Text directive grammar</span></a>
        </ol>
       <li>
        <a href="#allow-text-fragment-directives"><span class="secno">2.3</span> <span class="content">Security and Privacy</span></a>
@@ -1584,7 +1585,7 @@ the receiver loses the context of the page.
    <h2 class="heading settled" data-level="2" id="description"><span class="secno">2. </span><span class="content">Description</span><a class="self-link" href="#description"></a></h2>
    <h3 class="heading settled" data-level="2.1" id="syntax"><span class="secno">2.1. </span><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
    <div class="note" role="note">This section is non-normative</div>
-   <p>A text fragment is specified in the fragment directive (see <a href="#fragment-directive">§ 2.2 The Fragment Directive</a>) with the following format:</p>
+   <p>A <a data-link-type="dfn" href="#valid-text-directive" id="ref-for-valid-text-directive">valid text directive</a> is specified in the fragment directive (see <a href="#the-fragment-directive">§ 2.2 The Fragment Directive</a>) with the following format:</p>
 <pre>#:~:text=[prefix-,]textStart[,textEnd][,-suffix]
           context  |-------match-----|  context
 </pre>
@@ -1624,7 +1625,7 @@ visually indicated or affect the scroll position.</p>
    <div class="example" id="example-5c87b699"><a class="self-link" href="#example-5c87b699"></a> <code>#:~:text=this%20is-,an%20example,-text%20fragment</code> would match
 to "an example" in "this is an example text fragment", but not match to "an
 example" in "here is an example text". </div>
-   <h3 class="heading settled" data-level="2.2" id="fragment-directive"><span class="secno">2.2. </span><span class="content">The Fragment Directive</span><a class="self-link" href="#fragment-directive"></a></h3>
+   <h3 class="heading settled" data-level="2.2" id="the-fragment-directive"><span class="secno">2.2. </span><span class="content">The Fragment Directive</span><a class="self-link" href="#the-fragment-directive"></a></h3>
     To avoid compatibility issues with usage of existing URL fragments, this spec
 introduces the <em>fragment directive</em>. The fragment directive is a portion
 of the URL fragment delimited by the code sequence <code>:~:</code>. It is
@@ -1639,8 +1640,10 @@ translation-hints or enabling accessibility features.</p>
    <p>To the definition of a <a href="https://url.spec.whatwg.org/#concept-url"> URL record</a>, add:</p>
    <p><em> A URL’s fragment-directive is either null or an ASCII string holding data used
 by the UA to process the resource. It is initially null </em></p>
-   <p>Let the <em>fragment-directive delimiter</em> be the string ":~:", that is the
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-delimiter">fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> is the part of the URL fragment that follows
+the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive delimiter</a>.</p>
    <div class="note" role="note"> The fragment-directive is part of the URL fragment. This means it must always
   appear after a U+0023 (#) code point in a URL. </div>
    <div class="example" id="example-8a44ecf3"><a class="self-link" href="#example-8a44ecf3"></a> To add a fragment-directive to a URL like https://example.com, a fragment
@@ -1657,7 +1660,7 @@ step 2:</p>
         <li data-md>
          <p>If <em>c</em> is U+003A (:) and <em>remaining</em> begins with the two
 consecutive code points U+007E (~) and U+003A (:), set state to <em>fragment-directive state</em>. Increment <em>c</em> by the
-length of the <em>fragment-directive delimiter</em> minus 1.</p>
+length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive delimiter</a> minus 1.</p>
        </ul>
       <li data-md>
        <p>Step 3 (now step 4 after the above change) must begin with "Otherwise,"</p>
@@ -1689,8 +1692,8 @@ and append the result to <em>url’s fragment-directive</em>.</p>
        </ul>
      </ul>
    </ul>
-   <div class="note" role="note"> These changes make a URL’s fragment end at the fragment directive delimiter.
-  The fragment-directive includes all characters that follow, but not including,
+   <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive delimiter</a>.
+  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive">fragment directive</a> includes all characters that follow, but not including,
   the delimiter. </div>
    <div class="example" id="example-cac370ee"><a class="self-link" href="#example-cac370ee"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
 the fragment is the string "test" and the fragment-directive is the string
@@ -1731,6 +1734,16 @@ web-exposed)</p>
     <li data-md>
      <p>Set the <em>document’s url</em> to be <em>url</em>.</p>
    </ol>
+   <h4 class="heading settled" data-level="2.2.4" id="text-directive-grammer"><span class="secno">2.2.4. </span><span class="content">Text directive grammar</span><a class="self-link" href="#text-directive-grammer"></a></h4>
+    A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-text-directive">valid text directive</dfn> is a sequence of characters that appears in
+the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①">fragment directive</a> that matches the production: 
+   <dl>
+     <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt> <dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a> ("&amp;text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters①">TextDirectiveParameters</a>)*</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters">TextDirectiveParameters</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring">TextMatchString</a> ("," <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring①">TextMatchString</a>)? ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix">TextDirectivePrefix</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring②">TextMatchString</a> "-"</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix">TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring③">TextMatchString</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchstring">TextMatchString</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar">TextMatchChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchchar">TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code> 
+    <div class="note" role="note"> A <a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar①">TextMatchChar</a> may be any <a href="https://url.spec.whatwg.org/#url-code-points">URL code point</a> that
+is not explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> syntax, that is "&amp;", "-", and ",",
+which must be percent-encoded. </div>
+     <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar">PercentEncodedChar</dfn> ::=</dt> <dd>"%" [a-zA-Z0-9]+</dd></code> 
+   </dl>
    <h3 class="heading settled" data-level="2.3" id="allow-text-fragment-directives"><span class="secno">2.3. </span><span class="content">Security and Privacy</span><a class="self-link" href="#allow-text-fragment-directives"></a></h3>
    <h4 class="heading settled" data-level="2.3.1" id="motivation"><span class="secno">2.3.1. </span><span class="content">Motivation</span><a class="self-link" href="#motivation"></a></h4>
    <div class="note" role="note">This section is non-normative</div>
@@ -1777,7 +1790,7 @@ element fragment as the indicated part of the document. </div>
 indicated part of the document</a>.</p>
    <ol>
     <li data-md>
-     <p>Let <em>fragment directive</em> be the document URL’s <a href="#fragment-directive">fragment directive</a>.</p>
+     <p>Let <em>fragment directive</em> be the document URL’s <a href="#fragment-directive" id="ref-for-fragment-directive②">fragment directive</a>.</p>
     <li data-md>
      <p>Let <em>is user activated</em> be true if the current navigation was <a href="https://html.spec.whatwg.org/#triggered-by-user-activation">triggered by
    user activation</a></p>
@@ -2296,8 +2309,18 @@ manipulations
   <ul class="index">
    <li><a href="#current-locale">current locale</a><span>, in §2.4.2</span>
    <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §2.6</span>
+   <li><a href="#fragment-directive">fragment directive</a><span>, in §2.2.1</span>
    <li><a href="#fragmentdirective">FragmentDirective</a><span>, in §2.6</span>
+   <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §2.2.1</span>
    <li><a href="#location">Location</a><span>, in §2.6</span>
+   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §2.2.4</span>
+   <li><a href="#textdirective">TextDirective</a><span>, in §2.2.4</span>
+   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §2.2.4</span>
+   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §2.2.4</span>
+   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §2.2.4</span>
+   <li><a href="#textmatchchar">TextMatchChar</a><span>, in §2.2.4</span>
+   <li><a href="#textmatchstring">TextMatchString</a><span>, in §2.2.4</span>
+   <li><a href="#valid-text-directive">valid text directive</a><span>, in §2.2.4</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -2314,6 +2337,68 @@ manipulations
 };
 
 </pre>
+  <aside class="dfn-panel" data-for="fragment-directive-delimiter">
+   <b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fragment-directive-delimiter">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter①">(2)</a> <a href="#ref-for-fragment-directive-delimiter②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fragment-directive">
+   <b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fragment-directive">2.2.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-fragment-directive①">2.2.4. Text directive grammar</a>
+    <li><a href="#ref-for-fragment-directive">2.4. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="valid-text-directive">
+   <b><a href="#valid-text-directive">#valid-text-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-valid-text-directive">2.1. Syntax</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="textdirective">
+   <b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirective">2.2.4. Text directive grammar</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="textdirectiveparameters">
+   <b><a href="#textdirectiveparameters">#textdirectiveparameters</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirectiveparameters">2.2.4. Text directive grammar</a> <a href="#ref-for-textdirectiveparameters①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="textdirectiveprefix">
+   <b><a href="#textdirectiveprefix">#textdirectiveprefix</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirectiveprefix">2.2.4. Text directive grammar</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="textdirectivesuffix">
+   <b><a href="#textdirectivesuffix">#textdirectivesuffix</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirectivesuffix">2.2.4. Text directive grammar</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="textmatchstring">
+   <b><a href="#textmatchstring">#textmatchstring</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textmatchstring">2.2.4. Text directive grammar</a> <a href="#ref-for-textmatchstring①">(2)</a> <a href="#ref-for-textmatchstring②">(3)</a> <a href="#ref-for-textmatchstring③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="textmatchchar">
+   <b><a href="#textmatchchar">#textmatchchar</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textmatchchar">2.2.4. Text directive grammar</a> <a href="#ref-for-textmatchchar①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="percentencodedchar">
+   <b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-percentencodedchar">2.2.4. Text directive grammar</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="current-locale">
    <b><a href="#current-locale">#current-locale</a></b><b>Referenced in:</b>
    <ul>

--- a/index.html
+++ b/index.html
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-17">17 October 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-18">18 October 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1524,7 +1524,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#parsing-the-fragment-directive"><span class="secno">2.2.1</span> <span class="content">Parsing the fragment directive</span></a>
         <li><a href="#serializing-the-fragment-directive"><span class="secno">2.2.2</span> <span class="content">Serializing the fragment directive</span></a>
         <li><a href="#processing-the-fragment-directive"><span class="secno">2.2.3</span> <span class="content">Processing the fragment directive</span></a>
-        <li><a href="#text-directive-grammer"><span class="secno">2.2.4</span> <span class="content">Text directive grammar</span></a>
+        <li><a href="#fragment-directive-grammar"><span class="secno">2.2.4</span> <span class="content">Fragment directive grammar</span></a>
        </ol>
       <li>
        <a href="#allow-text-fragment-directives"><span class="secno">2.3</span> <span class="content">Security and Privacy</span></a>
@@ -1734,13 +1734,20 @@ web-exposed)</p>
     <li data-md>
      <p>Set the <em>document’s url</em> to be <em>url</em>.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.2.4" id="text-directive-grammer"><span class="secno">2.2.4. </span><span class="content">Text directive grammar</span><a class="self-link" href="#text-directive-grammer"></a></h4>
-    A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-text-directive">valid text directive</dfn> is a sequence of characters that appears in
-the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①">fragment directive</a> that matches the production: 
+   <h4 class="heading settled" data-level="2.2.4" id="fragment-directive-grammar"><span class="secno">2.2.4. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
+    A <dfn data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive<a class="self-link" href="#valid-fragment-directive"></a></dfn> is a sequence of characters that appears
+in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①">fragment directive</a> that matches the production: 
+   <dl> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirective">FragmentDirective</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> ("&amp;" <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a>)*</dd></code> </dl>
+   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective">FragmentDirective</a> may contain multiple directives split by the "&amp;"
+character. Currently this means we allow multiple text directives to enable
+multiple indicated strings in the page, but this also allows for future
+directive types to be added and combined. </div>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-text-directive">valid text directive</dfn> is one such directive, that matches the
+production:</p>
    <dl>
-     <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt> <dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a> ("&amp;text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters①">TextDirectiveParameters</a>)*</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters">TextDirectiveParameters</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring">TextMatchString</a> ("," <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring①">TextMatchString</a>)? ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix">TextDirectivePrefix</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring②">TextMatchString</a> "-"</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix">TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring③">TextMatchString</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchstring">TextMatchString</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar">TextMatchChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchchar">TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code> 
+     <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt> <dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters">TextDirectiveParameters</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring">TextMatchString</a> ("," <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring①">TextMatchString</a>)? ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix">TextDirectivePrefix</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring②">TextMatchString</a> "-"</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix">TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring③">TextMatchString</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchstring">TextMatchString</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar">TextMatchChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchchar">TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code> 
     <div class="note" role="note"> A <a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar①">TextMatchChar</a> may be any <a href="https://url.spec.whatwg.org/#url-code-points">URL code point</a> that
-is not explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> syntax, that is "&amp;", "-", and ",",
+is not explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a> syntax, that is "&amp;", "-", and ",",
 which must be percent-encoded. </div>
      <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar">PercentEncodedChar</dfn> ::=</dt> <dd>"%" [a-zA-Z0-9]+</dd></code> 
    </dl>
@@ -2050,13 +2057,13 @@ exfiltration.</p>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
 that is exposed via window.location.fragmentDirective if the UA supports the
 feature.</p>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="fragmentdirective"><code><c- g>FragmentDirective</c-></code></dfn> {
+<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="fragmentdirective①"><code><c- g>FragmentDirective</c-></code></dfn> {
 };
 </pre>
    <p>We amend <a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface">The
 Location Interface</a> to include a fragmentDirective property:</p>
 <pre class="idl highlight def"><c- b>interface</c-> <dfn class="idl-code" data-dfn-type="interface" data-export id="location"><code><c- g>Location</c-></code><a class="self-link" href="#location"></a></dfn> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-location-fragmentdirective"></a></dfn>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective①" id="ref-for-fragmentdirective①"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-location-fragmentdirective"></a></dfn>;
 };
 </pre>
    <h2 class="heading settled" data-level="3" id="generating-text-fragment-directives"><span class="secno">3. </span><span class="content">Generating Text Fragment Directives</span><a class="self-link" href="#generating-text-fragment-directives"></a></h2>
@@ -2310,7 +2317,12 @@ manipulations
    <li><a href="#current-locale">current locale</a><span>, in §2.4.2</span>
    <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §2.6</span>
    <li><a href="#fragment-directive">fragment directive</a><span>, in §2.2.1</span>
-   <li><a href="#fragmentdirective">FragmentDirective</a><span>, in §2.6</span>
+   <li>
+    FragmentDirective
+    <ul>
+     <li><a href="#fragmentdirective①">(interface)</a><span>, in §2.6</span>
+     <li><a href="#fragmentdirective">definition of</a><span>, in §2.2.4</span>
+    </ul>
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §2.2.1</span>
    <li><a href="#location">Location</a><span>, in §2.6</span>
    <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §2.2.4</span>
@@ -2320,6 +2332,7 @@ manipulations
    <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §2.2.4</span>
    <li><a href="#textmatchchar">TextMatchChar</a><span>, in §2.2.4</span>
    <li><a href="#textmatchstring">TextMatchString</a><span>, in §2.2.4</span>
+   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §2.2.4</span>
    <li><a href="#valid-text-directive">valid text directive</a><span>, in §2.2.4</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -2329,11 +2342,11 @@ manipulations
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><c- b>interface</c-> <a href="#fragmentdirective"><code><c- g>FragmentDirective</c-></code></a> {
+<pre class="idl highlight def"><c- b>interface</c-> <a href="#fragmentdirective①"><code><c- g>FragmentDirective</c-></code></a> {
 };
 
 <c- b>interface</c-> <a href="#location"><code><c- g>Location</c-></code></a> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective①"><c- n>FragmentDirective</c-></a> <a data-readonly data-type="FragmentDirective" href="#dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective①" id="ref-for-fragmentdirective①①"><c- n>FragmentDirective</c-></a> <a data-readonly data-type="FragmentDirective" href="#dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code></a>;
 };
 
 </pre>
@@ -2347,8 +2360,14 @@ manipulations
    <b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-directive">2.2.1. Parsing the fragment directive</a>
-    <li><a href="#ref-for-fragment-directive①">2.2.4. Text directive grammar</a>
+    <li><a href="#ref-for-fragment-directive①">2.2.4. Fragment directive grammar</a>
     <li><a href="#ref-for-fragment-directive">2.4. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fragmentdirective">
+   <b><a href="#fragmentdirective">#fragmentdirective</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fragmentdirective">2.2.4. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="valid-text-directive">
@@ -2360,43 +2379,43 @@ manipulations
   <aside class="dfn-panel" data-for="textdirective">
    <b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirective">2.2.4. Text directive grammar</a>
+    <li><a href="#ref-for-textdirective">2.2.4. Fragment directive grammar</a> <a href="#ref-for-textdirective①">(2)</a> <a href="#ref-for-textdirective②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveparameters">
    <b><a href="#textdirectiveparameters">#textdirectiveparameters</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectiveparameters">2.2.4. Text directive grammar</a> <a href="#ref-for-textdirectiveparameters①">(2)</a>
+    <li><a href="#ref-for-textdirectiveparameters">2.2.4. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveprefix">
    <b><a href="#textdirectiveprefix">#textdirectiveprefix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectiveprefix">2.2.4. Text directive grammar</a>
+    <li><a href="#ref-for-textdirectiveprefix">2.2.4. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectivesuffix">
    <b><a href="#textdirectivesuffix">#textdirectivesuffix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectivesuffix">2.2.4. Text directive grammar</a>
+    <li><a href="#ref-for-textdirectivesuffix">2.2.4. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textmatchstring">
    <b><a href="#textmatchstring">#textmatchstring</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textmatchstring">2.2.4. Text directive grammar</a> <a href="#ref-for-textmatchstring①">(2)</a> <a href="#ref-for-textmatchstring②">(3)</a> <a href="#ref-for-textmatchstring③">(4)</a>
+    <li><a href="#ref-for-textmatchstring">2.2.4. Fragment directive grammar</a> <a href="#ref-for-textmatchstring①">(2)</a> <a href="#ref-for-textmatchstring②">(3)</a> <a href="#ref-for-textmatchstring③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textmatchchar">
    <b><a href="#textmatchchar">#textmatchchar</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textmatchchar">2.2.4. Text directive grammar</a> <a href="#ref-for-textmatchchar①">(2)</a>
+    <li><a href="#ref-for-textmatchchar">2.2.4. Fragment directive grammar</a> <a href="#ref-for-textmatchchar①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="percentencodedchar">
    <b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-percentencodedchar">2.2.4. Text directive grammar</a>
+    <li><a href="#ref-for-percentencodedchar">2.2.4. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="current-locale">
@@ -2405,10 +2424,10 @@ manipulations
     <li><a href="#ref-for-current-locale">2.4.2. Find an exact match with context</a> <a href="#ref-for-current-locale①">(2)</a> <a href="#ref-for-current-locale②">(3)</a> <a href="#ref-for-current-locale③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentdirective">
-   <b><a href="#fragmentdirective">#fragmentdirective</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="fragmentdirective①">
+   <b><a href="#fragmentdirective①">#fragmentdirective①</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragmentdirective">2.6. Feature Detectability</a>
+    <li><a href="#ref-for-fragmentdirective①">2.6. Feature Detectability</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version ab064036f6954708ab86ed349b68bf5950f5dceb" name="generator">
+  <meta content="Bikeshed version 5edf8bee6cb6f00d270bf8e0fbb20d6ccc477cfd" name="generator">
   <link href="wicg.github.io/ScrollToTextFragment/draftspec.html" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1225,72 +1225,6 @@ Possible extra rowspan handling
 [data-md] > :last-child {
     margin-bottom: 0;
 }</style>
-<style>/* style-counters */
-
-body {
-    counter-reset: example figure issue;
-}
-.issue {
-    counter-increment: issue;
-}
-.issue:not(.no-marker)::before {
-    content: "Issue " counter(issue);
-}
-
-.example {
-    counter-increment: example;
-}
-.example:not(.no-marker)::before {
-    content: "Example " counter(example);
-}
-.invalid.example:not(.no-marker)::before,
-.illegal.example:not(.no-marker)::before {
-    content: "Invalid Example" counter(example);
-}
-
-figcaption {
-    counter-increment: figure;
-}
-figcaption:not(.no-marker)::before {
-    content: "Figure " counter(figure) " ";
-}</style>
-<style>/* style-dfn-panel */
-
-.dfn-panel {
-    position: absolute;
-    z-index: 35;
-    height: auto;
-    width: -webkit-fit-content;
-    width: fit-content;
-    max-width: 300px;
-    max-height: 500px;
-    overflow: auto;
-    padding: 0.5em 0.75em;
-    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-    background: #DDDDDD;
-    color: black;
-    border: outset 0.2em;
-}
-.dfn-panel:not(.on) { display: none; }
-.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
-.dfn-panel > b { display: block; }
-.dfn-panel a { color: black; }
-.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-.dfn-panel > b + b { margin-top: 0.25em; }
-.dfn-panel ul { padding: 0; }
-.dfn-panel li { list-style: inside; }
-.dfn-panel.activated {
-    display: inline-block;
-    position: fixed;
-    left: .5em;
-    bottom: 2em;
-    margin: 0 auto;
-    max-width: calc(100vw - 1.5em - .4em - .5em);
-    max-height: 30vh;
-}
-
-.dfn-paneled { cursor: pointer; }
-</style>
 <style>/* style-selflinks */
 
 .heading, .issue, .note, .example, li, dt {
@@ -1337,6 +1271,35 @@ dfn > a.self-link:hover {
 a.self-link::before            { content: "¶"; }
 .heading > a.self-link::before { content: "§"; }
 dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-counters */
+
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}</style>
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1399,11 +1362,106 @@ pre .property::before, pre .property::after {
 [data-link-type=biblio] {
     white-space: pre;
 }</style>
+<style>/* style-dfn-panel */
+
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    height: auto;
+    width: -webkit-fit-content;
+    width: fit-content;
+    max-width: 300px;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: #DDDDDD;
+    color: black;
+    border: outset 0.2em;
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: black; }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0; }
+.dfn-panel li { list-style: inside; }
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: .5em;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+}
+
+.dfn-paneled { cursor: pointer; }
+</style>
+<style>/* style-syntax-highlighting */
+pre.idl.highlight { color: #708090; }
+.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-08">8 October 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-09">9 October 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1475,6 +1533,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#advance-walker-to-text"><span class="secno">2.3.3</span> <span class="content">Advance a TreeWalker to the next text node</span></a>
         <li><a href="#next-word-bounded-instance"><span class="secno">2.3.4</span> <span class="content">Find the next word bounded instance</span></a>
        </ol>
+      <li><a href="#feature-detectability"><span class="secno">2.4</span> <span class="content">Feature Detectability</span></a>
      </ol>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
@@ -1487,6 +1546,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <ol class="toc">
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
      </ol>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
    </ol>
   </nav>
   <main>
@@ -1575,7 +1635,7 @@ step 2:</p>
        <ul>
         <li data-md>
          <p>If <em>c</em> is U+003A (:) and <em>remaining</em> begins with the two
-code points U+007E (~) and U+003A (:), set state to <em>fragment-directive state</em>. Increment <em>c</em> by the
+consecutive code points U+007E (~) and U+003A (:), set state to <em>fragment-directive state</em>. Increment <em>c</em> by the
 length of the <em>fragment-directive delimiter</em> minus 1.</p>
        </ul>
       <li data-md>
@@ -1893,6 +1953,19 @@ bound</em> immediately follows <em>range</em>, then return <em>range</em>.</p>
     <li data-md>
      <p>Return <em>null</em>.</p>
    </ol>
+   <h3 class="heading settled" data-level="2.4" id="feature-detectability"><span class="secno">2.4. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
+   <p>For feature detectability, we propose adding a new FragmentDirective interface
+that is exposed via window.location.fragmentDirective if the UA supports the
+feature.</p>
+<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="fragmentdirective"><code><c- g>FragmentDirective</c-></code></dfn> {
+};
+</pre>
+   <p>We amend <a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface">The
+Location Interface</a> to include a fragmentDirective property:</p>
+<pre class="idl highlight def"><c- b>interface</c-> <dfn class="idl-code" data-dfn-type="interface" data-export id="location"><code><c- g>Location</c-></code><a class="self-link" href="#location"></a></dfn> {
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-location-fragmentdirective"></a></dfn>;
+};
+</pre>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
@@ -2044,6 +2117,9 @@ bound</em> immediately follows <em>range</em>, then return <em>range</em>.</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#current-locale">current locale</a><span>, in §2.3.2</span>
+   <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §2.4</span>
+   <li><a href="#fragmentdirective">FragmentDirective</a><span>, in §2.4</span>
+   <li><a href="#location">Location</a><span>, in §2.4</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -2051,10 +2127,25 @@ bound</em> immediately follows <em>range</em>, then return <em>range</em>.</p>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
   </dl>
+  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl highlight def"><c- b>interface</c-> <a href="#fragmentdirective"><code><c- g>FragmentDirective</c-></code></a> {
+};
+
+<c- b>interface</c-> <a href="#location"><code><c- g>Location</c-></code></a> {
+    <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective①"><c- n>FragmentDirective</c-></a> <a data-readonly data-type="FragmentDirective" href="#dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code></a>;
+};
+
+</pre>
   <aside class="dfn-panel" data-for="current-locale">
    <b><a href="#current-locale">#current-locale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-locale">2.3.2. Find an exact match with context</a> <a href="#ref-for-current-locale①">(2)</a> <a href="#ref-for-current-locale②">(3)</a> <a href="#ref-for-current-locale③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fragmentdirective">
+   <b><a href="#fragmentdirective">#fragmentdirective</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fragmentdirective">2.4. Feature Detectability</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
Fixes #32 by adding a formal grammar for text directives. Also modified a couple of terms to be proper `<dfn>`s ("fragment directive" and "fragment directive delimiter"), note there are many other terms that should be `<dfn>`s, I'll clean these up in a separate PR addressing #36.