### PR TITLE
Increase pointer, not c

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -151,7 +151,7 @@ basic URL parser</a> steps to parse fragment directives in a URL:
         step 2:
         - If <em>c</em> is U+003A (:) and <em>remaining</em> begins with the two
             consecutive code points U+007E (~) and U+003A (:), set state to
-            <em>fragment-directive state</em>. Increment <em>c</em> by the
+            <em>fragment-directive state</em>. Increase <em>pointer</em> by the
             length of the [=fragment directive delimiter=] minus 1.
     - Step 3 (now step 4 after the above change) must begin with "Otherwise,"
   - In step 11 of this algorithm, add a new <em>fragment-directive state</em>

--- a/index.html
+++ b/index.html
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-18">18 October 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-21">21 October 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1659,7 +1659,7 @@ step 2:</p>
        <ul>
         <li data-md>
          <p>If <em>c</em> is U+003A (:) and <em>remaining</em> begins with the two
-consecutive code points U+007E (~) and U+003A (:), set state to <em>fragment-directive state</em>. Increment <em>c</em> by the
+consecutive code points U+007E (~) and U+003A (:), set state to <em>fragment-directive state</em>. Increase <em>pointer</em> by the
 length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive delimiter</a> minus 1.</p>
        </ul>
       <li data-md>


### PR DESCRIPTION
To advance `c` we increase `pointer` as the URL spec does. By definition, `c` is the character currently at `pointer`. Fixes #33.