### PR TITLE
Specifically remove the syntactic '-' from context terms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -342,12 +342,12 @@ user agent must run these steps:
     </div>
 6. Let <em>potential prefix</em> be the first item of <em>tokens</em>.
 7. If the last character of <em>potential prefix</em> is U+002D (-), then:
-    1. Set <em>prefix</em> to the result of removing any U+002D (-) from
+    1. Set <em>prefix</em> to the result of removing the last character from
         <em>potential prefix</em>.
     2. Remove the first item of the list <em>tokens</em>.
 8. Let <em>potential suffix</em> be the last item of <em>tokens</em>.
 9. If the first character of <em>potential suffix</em> is U+002D (-), then:
-    1. Set <em>suffix</em> to the result of removing any U+002D (-) from
+    1. Set <em>suffix</em> to the result of removing the first character from
         <em>potential suffix</em>.
     2. Remove the last item of the list <em>tokens</em>.
 10. Assert: <em>tokens</em> has size 1 or <em>tokens</em> has size 2.

--- a/index.html
+++ b/index.html
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-18">18 October 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-21">21 October 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1840,7 +1840,7 @@ directive. </div>
      <p>If the last character of <em>potential prefix</em> is U+002D (-), then:</p>
      <ol>
       <li data-md>
-       <p>Set <em>prefix</em> to the result of removing any U+002D (-) from <em>potential prefix</em>.</p>
+       <p>Set <em>prefix</em> to the result of removing the last character from <em>potential prefix</em>.</p>
       <li data-md>
        <p>Remove the first item of the list <em>tokens</em>.</p>
      </ol>
@@ -1850,7 +1850,7 @@ directive. </div>
      <p>If the first character of <em>potential suffix</em> is U+002D (-), then:</p>
      <ol>
       <li data-md>
-       <p>Set <em>suffix</em> to the result of removing any U+002D (-) from <em>potential suffix</em>.</p>
+       <p>Set <em>suffix</em> to the result of removing the first character from <em>potential suffix</em>.</p>
       <li data-md>
        <p>Remove the last item of the list <em>tokens</em>.</p>
      </ol>


### PR DESCRIPTION
Specifically remove the correct `-` character from context terms, as opposed to "any" `-` character (which, based on validation rules, should be the only `-`). Fixes #35.