### PR TITLE
Improve definitions and cross-spec references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -192,7 +192,8 @@ Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer
 
 8. If the <em>exclude fragment flag</em> is unset and [=URL's fragment directive=] is
     non-null:
-    1. If <em>url's fragment</em> is null, append U+0023 (#) to <em>output</em>.
+    1. If [[URL#concept-url-fragment|url's fragment]] is null, append U+0023 (#)
+        to <em>output</em>.
     2. Append ":~:", followed by [=URL's fragment directive=], to <em>output</em>.
 
 ### Processing the fragment directive ### {#processing-the-fragment-directive}
@@ -213,13 +214,12 @@ create and initialize a Document object</a> steps to store and remove the
 Replace steps 7 and 8 of this algorithm with:
 
 7. Let <em>url</em> be null
-8. If <em>request</em> is non-null, then set <em>url</em> to <em>request's
-    current URL</em>.
-9. Otherwise, set <em>url</em> to <em>response's URL</em>.
+8. If <em>request</em> is non-null, then set <em>document</em>'s [[DOM#concept-document-url|URL]] to <em>request</em>'s [[FETCH#concept-request-current-url|current URL]].
+9. Otherwise, set <em>url</em> to <em>response</em>'s [[FETCH#concept-response-url|URL]].
 10. Set [=Document's fragment directive=] to [=URL's fragment directive=].
     (Note: this is stored on the document but not web-exposed)
 11. Set [=URL's fragment directive=] to null.
-12. Set the <em>document's url</em> to be <em>url</em>.
+12. Set <em>document</em>'s [[DOM#concept-document-url|URL]] to be <em>url</em>.
 
 ### Fragment directive grammar ### {#fragment-directive-grammar}
 A <dfn>valid fragment directive</dfn> is a sequence of characters that appears

--- a/index.bs
+++ b/index.bs
@@ -147,26 +147,26 @@ Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser">
 basic URL parser</a> steps to parse fragment directives in a URL:
 
   - In step 11 of this algorithm, amend the <em>fragment state</em> case:
-    - In the inner switch on <em>c</em>, in the Otherwise case, add a step after
+    - In the inner switch on [[URL#c]], in the Otherwise case, add a step after
         step 2:
-        - If <em>c</em> is U+003A (:) and <em>remaining</em> begins with the two
+        - If [[URL#c]] is U+003A (:) and <em>remaining</em> begins with the two
             consecutive code points U+007E (~) and U+003A (:), set state to
-            <em>fragment-directive state</em>. Increase <em>pointer</em> by the
+            <em>fragment-directive state</em>. Increment [[URL#pointer]] by the
             length of the [=fragment directive delimiter=] minus 1.
     - Step 3 (now step 4 after the above change) must begin with "Otherwise,"
   - In step 11 of this algorithm, add a new <em>fragment-directive state</em>
     case with the following steps:
     
     <em>fragment-directive state</em>:
-    - Switching on <em>c</em>:
+    - Switching on [[URL#c]]:
         - The EOF code point: Do nothing
         - U+0000 NULL: Validation error
         - Otherwise:
-            1. If <em>c</em> is not a URL code point and not U+0025 (%), validation
+            1. If [[URL#c]] is not a URL code point and not U+0025 (%), validation
                 error.
-            2. If <em>c</em> is U+0025 (%) and <em>remaining</em> does not start with
+            2. If [[URL#c]] is U+0025 (%) and <em>remaining</em> does not start with
                 two ASCII hex digits, validation error.
-            3. UTF-8 percent encode <em>c</em> using the fragment percent-encode set
+            3. UTF-8 percent encode [[URL#c]] using the fragment percent-encode set
                 and append the result to <em>url’s fragment-directive</em>.
 
 <div class="note">

--- a/index.bs
+++ b/index.bs
@@ -167,7 +167,7 @@ basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
             2. If [[URL#c]] is U+0025 (%) and <em>remaining</em> does not start with
                 two ASCII hex digits, validation error.
             3. UTF-8 percent encode [[URL#c]] using the fragment percent-encode set
-                and append the result to <em>url’s fragment-directive</em>.
+                and append the result to <em>url’s</em> [=fragment directive=].
 
 <div class="note">
   These changes make a URL's fragment end at the [=fragment directive delimiter=].
@@ -186,10 +186,10 @@ the fragment is the string "test" and the [=fragment directive=] is the string
 Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer
 </a> steps by inserting a step after step 7:
 
-8. If the <em>exclude fragment flag</em> is unset and <em>url's fragment-directive</em> is
+8. If the <em>exclude fragment flag</em> is unset and <em>url's</em> [=fragment directive=] is
     non-null:
     1. If <em>url's fragment</em> is null, append U+0023 (#) to <em>output</em>.
-    2. Append ":~:", followed by <em>url's fragment-directive</em>, to <em>output</em>.
+    2. Append ":~:", followed by <em>url's</em> [=fragment directive=], to <em>output</em>.
 
 ### Processing the fragment directive ### {#processing-the-fragment-directive}
 
@@ -211,10 +211,10 @@ Replace steps 7 and 8 of this algorithm with:
 8. If <em>request</em> is non-null, then set <em>url</em> to <em>request's
     current URL</em>.
 9. Otherwise, set <em>url</em> to <em>response's URL</em>.
-10. Set <em>document's fragment-directive</em> be <em>url's
-    fragment-directive</em>.  (Note: this is stored on the document but not
+10. Set <em>document's</em> [=fragment directive=] be <em>url's</em>
+    [=fragment directive=].  (Note: this is stored on the document but not
     web-exposed)
-11. Set <em>url's fragment-directive</em> to null.
+11. Set <em>url's</em> [=fragment directive=] to null.
 12. Set the <em>document's url</em> to be <em>url</em>.
 
 ### Fragment directive grammar ### {#fragment-directive-grammar}

--- a/index.bs
+++ b/index.bs
@@ -252,7 +252,7 @@ which must be percent-encoded.
 
 ## Security and Privacy ## {#allow-text-fragment-directives}
 
-### Motivation
+### Motivation ### {#motivation}
 
 <div class="note">This section is non-normative</div>
 
@@ -284,11 +284,14 @@ invoke.
 </div>
 
 1. If any of the following conditions are true, return false.
-  * <em>window</em>'s parent field is non-null.
-  * <em>window</em>'s opener field is non-null.
-  * The document of the previous entry in <em>window</em>'s browsing context's session history is equal to <em>window</em>'s document.
-    <div class="note">That is, this is the result of a same document navigation</div>
-  * <em>is user triggered</em> is false.
+    * <em>window</em>'s parent field is non-null.
+    * <em>window</em>'s opener field is non-null.
+    * The document of the previous entry in <em>window</em>'s browsing context's
+        session history is equal to <em>window</em>'s document.
+        <div class="note">
+        That is, this is the result of a same document navigation
+        </div>
+    * <em>is user triggered</em> is false.
 2. Otherwise, return true.
 
 
@@ -305,19 +308,19 @@ href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated
 indicated part of the document</a>.
 
 1. Let <em>fragment directive</em> be the document URL's
-   <a href="#fragment-directive">fragment directive</a>. 
+    <a href="#fragment-directive">fragment directive</a>. 
 2. Let <em>is user activated</em> be true if the current navigation was <a
-   href="https://html.spec.whatwg.org/#triggered-by-user-activation">triggered by
-   user activation</a>
-   <div class="note">
-      TODO: This might need an additional flag somewhere to track the user
-      activation triggering
-   </div>
+    href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
+    by user activation</a>
+    <div class="note">
+    TODO: This might need an additional flag somewhere to track the user
+    activation triggering
+    </div>
 3. If the result of [[#should-allow-text-fragment]] with the window of the
-   document's browsing context and <em>is user activated</em> is true then:
+    document's browsing context and <em>is user activated</em> is true then:
     1. If [[#find-a-target-text]] with <em>fragment directive</em> returns
-       non-null, then the return value is the indicated part of the document;
-       return.
+        non-null, then the return value is the indicated part of the document;
+        return.
 
 ### Find a target text ### {#find-a-target-text}
 
@@ -575,7 +578,7 @@ This section contains recommendations for UAs automatically generating URLs
 with text fragment directives. These recommendations aren't normative but are
 provided to ensure generated URLs result in maximally stable and usable URLs.
 
-## Prefer Exact Matching To Range-based
+## Prefer Exact Matching To Range-based ## {#prefer-exact-matching-to-range-based}
 
 The match text can be provided either as an exact string "text=foo%20bar%20baz"
 or as a range "text=foo,bar".
@@ -625,7 +628,7 @@ as a range-based match.
   TODO:  Can we determine the above limit in some more objective way?
 </div>
 
-## Use Context Only When Necessary
+## Use Context Only When Necessary ## {#use-context-only-when-necessary}
 
 Context terms allow the text fragment directive to disambiguate text snippets
 on a page. However, their use can make the URL more brittle in some cases.
@@ -666,7 +669,7 @@ true:
   TODO: Determine the numeric limit above in a more objective way
 </div>
 
-## Determine If Fragment Id Is Needed
+## Determine If Fragment Id Is Needed ## {#determine-if-fragment-id-is-needed}
 
 When the UA navigates to a URL containing a text fragment directive, it will
 fallback to scrolling into view a regular element-id based fragment if it

--- a/index.bs
+++ b/index.bs
@@ -147,30 +147,30 @@ the [=fragment directive delimiter=].
 Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser">
 basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
 
-  - In step 11 of this algorithm, amend the [[URL#fragment-state]] case:
-    - In the inner switch on [[URL#c]], in the Otherwise case, add a step after
+  - In step 11 of this algorithm, amend the [[URL#fragment-state|fragment state]] case:
+    - In the inner switch on [[URL#c|c]], in the Otherwise case, add a step after
         step 2:
-        - If [[URL#c]] is U+003A (:) and
+        - If [[URL#c|c]] is U+003A (:) and
             <a href="https://url.spec.whatwg.org/#remaining">remaining</a>
             begins with the two consecutive code points U+007E (~) and U+003A
-            (:), set state to [=fragment directive state=]. Increment
-            [[URL#pointer]] by the length of the [=fragment directive
+            (:), set state to [=fragment directive state=]. Increment 
+            [[URL#pointer|pointer]] by the length of the [=fragment directive
             delimiter=] minus 1.
     - Step 3 (now step 4 after the above change) must begin with "Otherwise,"
   - In step 11 of this algorithm, add a new [=fragment directive state=]
     case with the following steps:
     
     <dfn>fragment directive state</dfn>:
-    - Switching on [[URL#c]]:
+    - Switching on [[URL#c|c]]:
         - The EOF code point: Do nothing
         - U+0000 NULL: Validation error
         - Otherwise:
-            1. If [[URL#c]] is not a URL code point and not U+0025 (%), validation
+            1. If [[URL#c|c]] is not a URL code point and not U+0025 (%), validation
                 error.
-            2. If [[URL#c]] is U+0025 (%) and
+            2. If [[URL#c|c]] is U+0025 (%) and
                 <a href="https://url.spec.whatwg.org/#remaining">remaining</a>
                 does not start with two ASCII hex digits, validation error.
-            3. UTF-8 percent encode [[URL#c]] using the fragment percent-encode set
+            3. UTF-8 percent encode [[URL#c|c]] using the fragment percent-encode set
                 and append the result to [=URL's fragment directive=].
 
 <div class="note">

--- a/index.bs
+++ b/index.bs
@@ -41,7 +41,7 @@ the receiver loses the context of the page.
 
 <div class='note'>This section is non-normative</div>
 
-A [=valid text directive=] is specified in the fragment directive (see
+A [=text fragment directive=] is specified in the [=fragment directive=] (see
 [[#the-fragment-directive]]) with the following format:
 <pre>
 #:~:text=[prefix-,]textStart[,textEnd][,-suffix]
@@ -106,7 +106,7 @@ example" in "here is an example text".
 
 ## The Fragment Directive ## {#the-fragment-directive}
 To avoid compatibility issues with usage of existing URL fragments, this spec
-introduces the <em>fragment directive</em>. The fragment directive is a portion
+introduces the [=fragment directive=]. The [=fragment directive=] is a portion
 of the URL fragment delimited by the code sequence <code>:~:</code>. It is
 reserved for UA instructions, such as text=, and is stripped from the URL
 during loading so that author scripts can't directly interact with it.
@@ -144,7 +144,7 @@ the [=fragment directive delimiter=].
 </div>
 
 Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser">
-basic URL parser</a> steps to parse fragment directives in a URL:
+basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
 
   - In step 11 of this algorithm, amend the <em>fragment state</em> case:
     - In the inner switch on [[URL#c]], in the Otherwise case, add a step after
@@ -197,13 +197,13 @@ To the definition of
 <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:
 
 <em>
-Each document has an associated fragment directive.
+Each document has an associated [=fragment directive=].
 </em>
 
 Amend the
 <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">
 create and initialize a Document object</a> steps to store and remove the
-fragment directive from the a Document's URL.
+[=fragment directive=] from the a Document's URL.
 
 Replace steps 7 and 8 of this algorithm with:
 
@@ -231,8 +231,8 @@ multiple indicated strings in the page, but this also allows for future
 directive types to be added and combined.
 </div>
 
-A <dfn>valid text directive</dfn> is one such directive, that matches the
-production:
+The <dfn>text fragment directive</dfn> is one such [=fragment directive=] that
+enables specifying a piece of text on the page, that matches the production:
 
 <dl>
 <code><dt><dfn>TextDirective</dfn> ::=</dt> <dd>"text=" [=TextDirectiveParameters=]</dd></code>
@@ -256,22 +256,22 @@ which must be percent-encoded.
 
 <div class="note">This section is non-normative</div>
 
-Care must be taken when implementing text fragment directive so that it
+Care must be taken when implementing [=text fragment directive=] so that it
 cannot be used to exfiltrate information across origins. Scripts can navigate
-a page to a cross-origin URL with a text fragment directive.  If a malicious
+a page to a cross-origin URL with a [=text fragment directive=].  If a malicious
 actor can determine that a victim page scrolled after such a navigation, they
 can infer the existence of any text on the page.
 
 In addition, the user's privacy should be ensured even from the destination
 origin.  Although scripts on that page can already learn a lot about a user's
-actions, a text fragment directive can still contain sensitive information. For
-this reason, this specification provides no way for a page to extract the
+actions, a [=text fragment directive=] can still contain sensitive information.
+For this reason, this specification provides no way for a page to extract the
 content of the text fragment anchor. User agents must not expose this
 information to the page.
 
 <div class="example">
   A user visiting a page listing dozens of medical conditions may have gotten
-  there via a link with a text fragment directive containing a specific
+  there via a link with a [=text fragment directive=] containing a specific
   condition. This information must not be shared with the page.
 </div>
 
@@ -279,7 +279,7 @@ information to the page.
 
 <div class="note">
 This algorithm has input <em>window, is user triggered</em> and returns a
-boolean indicating whether a text fragment directive should be allowed to
+boolean indicating whether a [=text fragment directive=] should be allowed to
 invoke.
 </div>
 
@@ -298,7 +298,7 @@ invoke.
 ## Navigating to a Text Fragment ## {#navigating-to-text-fragment}
 <div class="note">
 The scroll to text specification proposes an amendment to
-[[html#scroll-to-fragid]]. In summary, if a text fragment directive is present
+[[html#scroll-to-fragid]]. In summary, if a [=text fragment directive=] is present
 and a match is found in the page, the text fragment takes precedent over the
 element fragment as the indicated part of the document.
 </div>
@@ -307,8 +307,8 @@ Add the following steps to the beginning of the processing model for <a
 href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">The
 indicated part of the document</a>.
 
-1. Let <em>fragment directive</em> be the document URL's
-    <a href="#fragment-directive">fragment directive</a>. 
+1. Let <dfn>fragment directive string</dfn> be the document URL's [=fragment
+    directive=]. 
 2. Let <em>is user activated</em> be true if the current navigation was <a
     href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
     by user activation</a>
@@ -318,20 +318,20 @@ indicated part of the document</a>.
     </div>
 3. If the result of [[#should-allow-text-fragment]] with the window of the
     document's browsing context and <em>is user activated</em> is true then:
-    1. If [[#find-a-target-text]] with <em>fragment directive</em> returns
+    1. If [[#find-a-target-text]] with [=fragment directive string=] returns
         non-null, then the return value is the indicated part of the document;
         return.
 
 ### Find a target text ### {#find-a-target-text}
 
-To find the target text for a given string <em>fragment directive</em>, the
-user agent must run these steps:
-1. If <em>fragment directive</em> does not begin with the string "text=",
+To find the target text for a given string <dfn>fragment directive input</dfn>,
+the user agent must run these steps:
+1. If [=fragment directive input=] does not begin with the string "text=",
     then return null.
-2. Let <em>raw target text</em> be the substring of <em>fragment directive</em>
+2. Let <em>raw target text</em> be the substring of [=fragment directive input=]
     starting at index 5.
     <div class="note">
-    This is the remainder of the fragment directive following, but not
+    This is the remainder of the [=fragment directive input=] following, but not
     including, the "text=" prefix.
     </div>
 3. If <em>raw target text</em> is the empty string, return null.
@@ -575,7 +575,7 @@ interface Location {
 </div>
 
 This section contains recommendations for UAs automatically generating URLs
-with text fragment directives. These recommendations aren't normative but are
+with a [=text fragment directive=]. These recommendations aren't normative but are
 provided to ensure generated URLs result in maximally stable and usable URLs.
 
 ## Prefer Exact Matching To Range-based ## {#prefer-exact-matching-to-range-based}
@@ -630,11 +630,11 @@ as a range-based match.
 
 ## Use Context Only When Necessary ## {#use-context-only-when-necessary}
 
-Context terms allow the text fragment directive to disambiguate text snippets
+Context terms allow the [=text fragment directive=] to disambiguate text snippets
 on a page. However, their use can make the URL more brittle in some cases.
 Often, the desired string will start or end at an element boundary. The context
 will therefore exist in an adjacent element. Changes to the page structure
-could invalidate the text fragment directive since the context and match text
+could invalidate the [=text fragment directive=] since the context and match text
 may no longer appear to be adjacent.
 
 <div class='example'>
@@ -645,7 +645,7 @@ may no longer appear to be adjacent.
         &lt;div class="content"&gt;Text to quote&lt;/div&gt;
   </pre>
 
-  We could craft the text fragment directive as follows:
+  We could craft the [=text fragment directive=] as follows:
 
   <pre>
     text=HEADER-,Text%20to%20quote
@@ -671,12 +671,12 @@ true:
 
 ## Determine If Fragment Id Is Needed ## {#determine-if-fragment-id-is-needed}
 
-When the UA navigates to a URL containing a text fragment directive, it will
+When the UA navigates to a URL containing a [=text fragment directive=], it will
 fallback to scrolling into view a regular element-id based fragment if it
 exists and the text fragment isn't found.
 
 This can be useful to provide a fallback, in case the text in the document
-changes, invalidating the text fragment directive.
+changes, invalidating the [=text fragment directive=].
 
 <div class='example'>
   Suppose we wish to craft a URL to

--- a/index.bs
+++ b/index.bs
@@ -111,7 +111,7 @@ of the URL fragment delimited by the code sequence <code>:~:</code>. It is
 reserved for UA instructions, such as text=, and is stripped from the URL
 during loading so that author scripts can't directly interact with it.
 
-The fragment-directive is a mechanism for URLs to specify instructions meant
+The [=fragment directive=] is a mechanism for URLs to specify instructions meant
 for the UA rather than the document. It's meant to avoid direct interaction with
 author script so that future UA instructions can be added without fear of
 introducing breaking changes to existing content. Potential examples could be:
@@ -123,7 +123,7 @@ To the definition of a <a href="https://url.spec.whatwg.org/#concept-url">
 URL record</a>, add:
 
 <em>
-A URL's fragment-directive is either null or an ASCII string holding data used
+A URL's [=fragment directive=] is either null or an ASCII string holding data used
 by the UA to process the resource. It is initially null
 </em>
 
@@ -134,12 +134,12 @@ The <dfn>fragment directive</dfn> is the part of the URL fragment that follows
 the [=fragment directive delimiter=].
 
 <div class="note">
-  The fragment-directive is part of the URL fragment. This means it must always
+  The [=fragment directive=] is part of the URL fragment. This means it must always
   appear after a U+0023 (#) code point in a URL. 
 </div>
 
 <div class="example">
-  To add a fragment-directive to a URL like https://example.com, a fragment
+  To add a [=fragment directive=] to a URL like https://example.com, a fragment
   must first be appended to the URL: https://example.com#:~:text=foo.
 </div>
 
@@ -177,7 +177,7 @@ basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
 
 <div class="example">
 <code>https://example.org/#test:~:text=foo</code> will be parsed such that
-the fragment is the string "test" and the fragment-directive is the string
+the fragment is the string "test" and the [=fragment directive=] is the string
 "text=foo".
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -151,13 +151,13 @@ basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
         step 2:
         - If [[URL#c]] is U+003A (:) and <em>remaining</em> begins with the two
             consecutive code points U+007E (~) and U+003A (:), set state to
-            <em>fragment-directive state</em>. Increment [[URL#pointer]] by the
+            [=fragment directive state=]. Increment [[URL#pointer]] by the
             length of the [=fragment directive delimiter=] minus 1.
     - Step 3 (now step 4 after the above change) must begin with "Otherwise,"
-  - In step 11 of this algorithm, add a new <em>fragment-directive state</em>
+  - In step 11 of this algorithm, add a new [=fragment directive state=]
     case with the following steps:
     
-    <em>fragment-directive state</em>:
+    <dfn>fragment directive state</dfn>:
     - Switching on [[URL#c]]:
         - The EOF code point: Do nothing
         - U+0000 NULL: Validation error

--- a/index.bs
+++ b/index.bs
@@ -135,8 +135,8 @@ The <dfn>fragment directive</dfn> is the part of the URL fragment that follows
 the [=fragment directive delimiter=].
 
 <div class="note">
-  The [=fragment directive=] is part of the URL fragment. This means it must always
-  appear after a U+0023 (#) code point in a URL. 
+  The [=fragment directive=] is part of the URL fragment. This means it must
+  always appear after a U+0023 (#) code point in a URL. 
 </div>
 
 <div class="example">
@@ -147,9 +147,10 @@ the [=fragment directive delimiter=].
 Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser">
 basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
 
-  - In step 11 of this algorithm, amend the [[URL#fragment-state|fragment state]] case:
-    - In the inner switch on [[URL#c|c]], in the Otherwise case, add a step after
-        step 2:
+  - In step 11 of this algorithm, amend the [[URL#fragment-state|fragment
+    state]] case:
+    - In the inner switch on [[URL#c|c]], in the Otherwise case, add a step
+        after step 2:
         - If [[URL#c|c]] is U+003A (:) and
             <a href="https://url.spec.whatwg.org/#remaining">remaining</a>
             begins with the two consecutive code points U+007E (~) and U+003A
@@ -165,18 +166,19 @@ basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
         - The EOF code point: Do nothing
         - U+0000 NULL: Validation error
         - Otherwise:
-            1. If [[URL#c|c]] is not a URL code point and not U+0025 (%), validation
-                error.
+            1. If [[URL#c|c]] is not a URL code point and not U+0025 (%),
+                validation error.
             2. If [[URL#c|c]] is U+0025 (%) and
                 <a href="https://url.spec.whatwg.org/#remaining">remaining</a>
                 does not start with two ASCII hex digits, validation error.
-            3. UTF-8 percent encode [[URL#c|c]] using the fragment percent-encode set
-                and append the result to [=URL's fragment directive=].
+            3. UTF-8 percent encode [[URL#c|c]] using the fragment
+                percent-encode set and append the result to [=URL's fragment
+                directive=].
 
 <div class="note">
-  These changes make a URL's fragment end at the [=fragment directive delimiter=].
-  The [=fragment directive=] includes all characters that follow, but not including,
-  the delimiter.
+  These changes make a URL's fragment end at the [=fragment directive
+  delimiter=]. The [=fragment directive=] includes all characters that follow,
+  but not including, the delimiter.
 </div>
 
 <div class="example">
@@ -190,11 +192,12 @@ the fragment is the string "test" and the [=fragment directive=] is the string
 Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer
 </a> steps by inserting a step after step 7:
 
-8. If the <em>exclude fragment flag</em> is unset and [=URL's fragment directive=] is
-    non-null:
+8. If the <em>exclude fragment flag</em> is unset and [=URL's fragment
+    directive=] is non-null:
     1. If [[URL#concept-url-fragment|url's fragment]] is null, append U+0023 (#)
         to <em>output</em>.
-    2. Append ":~:", followed by [=URL's fragment directive=], to <em>output</em>.
+    2. Append ":~:", followed by [=URL's fragment directive=], to
+        <em>output</em>.
 
 ### Processing the fragment directive ### {#processing-the-fragment-directive}
 
@@ -214,8 +217,11 @@ create and initialize a Document object</a> steps to store and remove the
 Replace steps 7 and 8 of this algorithm with:
 
 7. Let <em>url</em> be null
-8. If <em>request</em> is non-null, then set <em>document</em>'s [[DOM#concept-document-url|URL]] to <em>request</em>'s [[FETCH#concept-request-current-url|current URL]].
-9. Otherwise, set <em>url</em> to <em>response</em>'s [[FETCH#concept-response-url|URL]].
+8. If <em>request</em> is non-null, then set <em>document</em>'s
+    [[DOM#concept-document-url|URL]] to <em>request</em>'s
+    [[FETCH#concept-request-current-url|current URL]].
+9. Otherwise, set <em>url</em> to <em>response</em>'s
+    [[FETCH#concept-response-url|URL]].
 10. Set [=Document's fragment directive=] to [=URL's fragment directive=].
     (Note: this is stored on the document but not web-exposed)
 11. Set [=URL's fragment directive=] to null.
@@ -225,7 +231,8 @@ Replace steps 7 and 8 of this algorithm with:
 A <dfn>valid fragment directive</dfn> is a sequence of characters that appears
 in the [=fragment directive=] that matches the production:
 <dl>
-<code><dt><dfn>FragmentDirective</dfn> ::=</dt> <dd>[=TextDirective=] ("&" [=TextDirective=])*</dd></code>
+<code><dt><dfn>FragmentDirective</dfn> ::=</dt>
+<dd>[=TextDirective=] ("&" [=TextDirective=])*</dd></code>
 </dl>
 
 <div class="note">
@@ -239,19 +246,33 @@ The <dfn>text fragment directive</dfn> is one such [=fragment directive=] that
 enables specifying a piece of text on the page, that matches the production:
 
 <dl>
-<code><dt><dfn>TextDirective</dfn> ::=</dt> <dd>"text=" [=TextDirectiveParameters=]</dd></code>
-<code><dt><dfn>TextDirectiveParameters</dfn> ::=</dt> <dd>([=TextDirectivePrefix=] ",")? [=TextMatchString=] ("," [=TextMatchString=])? ("," [=TextDirectiveSuffix=])?</dd></code>
-<code><dt><dfn>TextDirectivePrefix</dfn> ::=</dt> <dd>[=TextMatchString=] "-"</dd></code>
-<code><dt><dfn>TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" [=TextMatchString=]</dd></code>
-<code><dt><dfn>TextMatchString</dfn> ::=</dt> <dd>([=TextMatchChar=] | [=PercentEncodedChar=])+</dd></code>
-<code><dt><dfn>TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code>
+<code><dt><dfn>TextDirective</dfn> ::=</dt><dd>"text="
+[=TextDirectiveParameters=]</dd></code>
+
+<code><dt><dfn>TextDirectiveParameters</dfn> ::=</dt><dd>
+([=TextDirectivePrefix=] ",")? [=TextMatchString=] ("," [=TextMatchString=])?
+("," [=TextDirectiveSuffix=])?</dd></code>
+
+<code><dt><dfn>TextDirectivePrefix</dfn> ::=</dt><dd>[=TextMatchString=]
+"-"</dd></code>
+
+<code><dt><dfn>TextDirectiveSuffix</dfn> ::=</dt><dd>"-"
+[=TextMatchString=]</dd></code>
+
+<code><dt><dfn>TextMatchString</dfn> ::=</dt><dd>([=TextMatchChar=] |
+[=PercentEncodedChar=])+</dd></code>
+
+<code><dt><dfn>TextMatchChar</dfn> ::=</dt><dd>[a-zA-Z0-9] | "!" | "$" | "'" |
+"(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd>
+</code>
+
 <div class = "note">
 A [=TextMatchChar=] may be any
 <a href="https://url.spec.whatwg.org/#url-code-points">URL code point</a> that
-is not explicitly used in the [=TextDirective=] syntax, that is "&", "-", and ",",
-which must be percent-encoded.
+is not explicitly used in the [=TextDirective=] syntax, that is "&", "-", and
+",", which must be percent-encoded.
 </div>
-<code><dt><dfn>PercentEncodedChar</dfn> ::=</dt> <dd>"%" [a-zA-Z0-9]+</dd></code>
+<code><dt><dfn>PercentEncodedChar</dfn> ::=</dt><dd>"%" [a-zA-Z0-9]+</dd></code>
 </dl>
 
 ## Security and Privacy ## {#allow-text-fragment-directives}
@@ -289,11 +310,11 @@ invoke.
 
 1. If any of the following conditions are true, return false.
     * <em>window</em>'s
-        <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-parent">parent</a>
-        field is non-null.
+        <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-parent">
+        parent</a> field is non-null.
     * <em>window</em>'s
-        <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-opener">opener</a>
-        field is non-null.
+        <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-opener">
+        opener</a> field is non-null.
     * The <a href="https://html.spec.whatwg.org/#document">Document</a> of the
         [[HTML#latest-entry|latest entry]] in <em>window</em>'s
         [[HTML#browsing-context|browsing context]]'s
@@ -309,14 +330,14 @@ invoke.
 ## Navigating to a Text Fragment ## {#navigating-to-text-fragment}
 <div class="note">
 The scroll to text specification proposes an amendment to
-[[html#scroll-to-fragid]]. In summary, if a [=text fragment directive=] is present
-and a match is found in the page, the text fragment takes precedent over the
-element fragment as the indicated part of the document.
+[[html#scroll-to-fragid]]. In summary, if a [=text fragment directive=] is
+present and a match is found in the page, the text fragment takes precedent over
+the element fragment as the indicated part of the document.
 </div>
 
 Add the following steps to the beginning of the processing model for <a
-href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">The
-indicated part of the document</a>.
+href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">
+The indicated part of the document</a>.
 
 1. Let <em>fragment directive string</em> be the document [=URL's fragment
     directive=].
@@ -329,9 +350,9 @@ indicated part of the document</a>.
     </div>
 3. If the result of [[#should-allow-text-fragment]] with the window of the
     document's browsing context and <em>is user activated</em> is true then:
-    1. If [[#find-a-target-text]] with <em>fragment directive string</em> returns
-        non-null, then the return value is the indicated part of the document;
-        return.
+    1. If [[#find-a-target-text]] with <em>fragment directive string</em>
+        returns non-null, then the return value is the indicated part of the
+        document; return.
 
 ### Find a target text ### {#find-a-target-text}
 
@@ -339,11 +360,11 @@ To find the target text for a given string <em>fragment directive input</em>,
 the user agent must run these steps:
 1. If <em>fragment directive input</em> does not begin with the string "text=",
     then return null.
-2. Let <em>raw target text</em> be the substring of <em>fragment directive input</em>
-    starting at index 5.
+2. Let <em>raw target text</em> be the substring of <em>fragment directive
+    input</em> starting at index 5.
     <div class="note">
-    This is the remainder of the <em>fragment directive input</em> following, but not
-    including, the "text=" prefix.
+    This is the remainder of the <em>fragment directive input</em> following,
+    but not including, the "text=" prefix.
     </div>
 3. If <em>raw target text</em> is the empty string, return null.
 4. Let <em>tokens</em> be a [[INFRA#list|list]] of strings that is the result of
@@ -494,7 +515,8 @@ copy, i.e. any modifications are performed on the caller's instance of
 1. While the input <em>walker.currentNode</em> is not null and 
     <em>walker.currentNode</em> is not a text node:
     1. Advance the current node by calling
-        <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode">walker.nextNode()</a>
+        <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode">
+        walker.nextNode()</a>
 
 ### Find the next word bounded instance ### {#next-word-bounded-instance}
 <div class="note">
@@ -527,9 +549,9 @@ API for word boundary matching.
             href="http://www.unicode.org/reports/tr29/#Word_Boundaries">Unicode
             text segmentation annex</a>. The <a
             href="http://www.unicode.org/reports/tr29/#Default_Word_Boundaries">
-            Default Word Boundary Specification</a> defines a default set of what
-            constitutes a word boundary, but as the specification mentions, a
-            more sophisticated algorithm should be used based on the
+            Default Word Boundary Specification</a> defines a default set of
+            what constitutes a word boundary, but as the specification mentions,
+            a more sophisticated algorithm should be used based on the
             <em>locale</em>.
           </p>
           <p>
@@ -548,8 +570,8 @@ API for word boundary matching.
 ## Indicating The Text Match ## {#indicating-the-text-match}
 
 In addition to scrolling the text fragment into view as part of the <a
-href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">Try
-To Scroll To The Fragment</a> steps, the UA should visually indicate the
+href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">
+Try To Scroll To The Fragment</a> steps, the UA should visually indicate the
 matched text in some way such that the user is made aware of the text match.
 
 The UA should provide to the user some method of dismissing the match, such
@@ -575,8 +597,8 @@ interface FragmentDirective {
 </pre>
 
 We amend
-<a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface">The
-Location Interface</a> to include a <code>fragmentDirective</code> property:
+<a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface">
+The Location Interface</a> to include a <code>fragmentDirective</code> property:
 
 <pre class='idl'>
 interface Location {
@@ -591,8 +613,9 @@ interface Location {
 </div>
 
 This section contains recommendations for UAs automatically generating URLs
-with a [=text fragment directive=]. These recommendations aren't normative but are
-provided to ensure generated URLs result in maximally stable and usable URLs.
+with a [=text fragment directive=]. These recommendations aren't normative but
+are provided to ensure generated URLs result in maximally stable and usable
+URLs.
 
 ## Prefer Exact Matching To Range-based ## {#prefer-exact-matching-to-range-based}
 
@@ -646,12 +669,12 @@ as a range-based match.
 
 ## Use Context Only When Necessary ## {#use-context-only-when-necessary}
 
-Context terms allow the [=text fragment directive=] to disambiguate text snippets
-on a page. However, their use can make the URL more brittle in some cases.
-Often, the desired string will start or end at an element boundary. The context
-will therefore exist in an adjacent element. Changes to the page structure
-could invalidate the [=text fragment directive=] since the context and match text
-may no longer appear to be adjacent.
+Context terms allow the [=text fragment directive=] to disambiguate text
+snippets on a page. However, their use can make the URL more brittle in some
+cases. Often, the desired string will start or end at an element boundary. The
+context will therefore exist in an adjacent element. Changes to the page
+structure could invalidate the [=text fragment directive=] since the context and
+match text may no longer appear to be adjacent.
 
 <div class='example'>
   Suppose we wish to craft a URL for the following text:

--- a/index.bs
+++ b/index.bs
@@ -123,8 +123,9 @@ To the definition of a <a href="https://url.spec.whatwg.org/#concept-url">
 URL record</a>, add:
 
 <em>
-A URL's [=fragment directive=] is either null or an ASCII string holding data used
-by the UA to process the resource. It is initially null
+A [[URL#concept-url|URL]]'s <dfn lt="URL's fragment directive">fragment
+directive</dfn> is either null or an ASCII string holding data used by the UA to
+process the resource. It is initially null.
 </em>
 
 The <dfn>fragment directive delimiter</dfn> is the string ":~:", that is the
@@ -146,13 +147,15 @@ the [=fragment directive delimiter=].
 Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser">
 basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
 
-  - In step 11 of this algorithm, amend the <em>fragment state</em> case:
+  - In step 11 of this algorithm, amend the [[URL#fragment-state]] case:
     - In the inner switch on [[URL#c]], in the Otherwise case, add a step after
         step 2:
-        - If [[URL#c]] is U+003A (:) and <em>remaining</em> begins with the two
-            consecutive code points U+007E (~) and U+003A (:), set state to
-            [=fragment directive state=]. Increment [[URL#pointer]] by the
-            length of the [=fragment directive delimiter=] minus 1.
+        - If [[URL#c]] is U+003A (:) and
+            <a href="https://url.spec.whatwg.org/#remaining">remaining</a>
+            begins with the two consecutive code points U+007E (~) and U+003A
+            (:), set state to [=fragment directive state=]. Increment
+            [[URL#pointer]] by the length of the [=fragment directive
+            delimiter=] minus 1.
     - Step 3 (now step 4 after the above change) must begin with "Otherwise,"
   - In step 11 of this algorithm, add a new [=fragment directive state=]
     case with the following steps:
@@ -164,10 +167,11 @@ basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
         - Otherwise:
             1. If [[URL#c]] is not a URL code point and not U+0025 (%), validation
                 error.
-            2. If [[URL#c]] is U+0025 (%) and <em>remaining</em> does not start with
-                two ASCII hex digits, validation error.
+            2. If [[URL#c]] is U+0025 (%) and
+                <a href="https://url.spec.whatwg.org/#remaining">remaining</a>
+                does not start with two ASCII hex digits, validation error.
             3. UTF-8 percent encode [[URL#c]] using the fragment percent-encode set
-                and append the result to <em>url’s</em> [=fragment directive=].
+                and append the result to [=URL's fragment directive=].
 
 <div class="note">
   These changes make a URL's fragment end at the [=fragment directive delimiter=].
@@ -186,10 +190,10 @@ the fragment is the string "test" and the [=fragment directive=] is the string
 Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer
 </a> steps by inserting a step after step 7:
 
-8. If the <em>exclude fragment flag</em> is unset and <em>url's</em> [=fragment directive=] is
+8. If the <em>exclude fragment flag</em> is unset and [=URL's fragment directive=] is
     non-null:
     1. If <em>url's fragment</em> is null, append U+0023 (#) to <em>output</em>.
-    2. Append ":~:", followed by <em>url's</em> [=fragment directive=], to <em>output</em>.
+    2. Append ":~:", followed by [=URL's fragment directive=], to <em>output</em>.
 
 ### Processing the fragment directive ### {#processing-the-fragment-directive}
 
@@ -197,7 +201,8 @@ To the definition of
 <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:
 
 <em>
-Each document has an associated [=fragment directive=].
+Each document has an associated <dfn lt="Document's fragment directive">fragment
+directive</dfn>.
 </em>
 
 Amend the
@@ -211,10 +216,9 @@ Replace steps 7 and 8 of this algorithm with:
 8. If <em>request</em> is non-null, then set <em>url</em> to <em>request's
     current URL</em>.
 9. Otherwise, set <em>url</em> to <em>response's URL</em>.
-10. Set <em>document's</em> [=fragment directive=] be <em>url's</em>
-    [=fragment directive=].  (Note: this is stored on the document but not
-    web-exposed)
-11. Set <em>url's</em> [=fragment directive=] to null.
+10. Set [=Document's fragment directive=] to [=URL's fragment directive=].
+    (Note: this is stored on the document but not web-exposed)
+11. Set [=URL's fragment directive=] to null.
 12. Set the <em>document's url</em> to be <em>url</em>.
 
 ### Fragment directive grammar ### {#fragment-directive-grammar}
@@ -307,8 +311,8 @@ Add the following steps to the beginning of the processing model for <a
 href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">The
 indicated part of the document</a>.
 
-1. Let <dfn>fragment directive string</dfn> be the document URL's [=fragment
-    directive=]. 
+1. Let <dfn>fragment directive string</dfn> be the document [=URL's fragment
+    directive=].
 2. Let <em>is user activated</em> be true if the current navigation was <a
     href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
     by user activation</a>

--- a/index.bs
+++ b/index.bs
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Status: CG-DRAFT
 Title: Scroll To Text Fragment
-ED: wicg.github.io/ScrollToTextFragment/draftspec.html
+ED: wicg.github.io/ScrollToTextFragment/index.html
 Shortname: scroll-to-text
 Level: 1
 Editor: Nick Burris, Google https://www.google.com, nburris@chromium.org
@@ -154,7 +154,7 @@ basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
             <a href="https://url.spec.whatwg.org/#remaining">remaining</a>
             begins with the two consecutive code points U+007E (~) and U+003A
             (:), set state to [=fragment directive state=]. Increment 
-            [[URL#pointer|pointer]] by the length of the [=fragment directive
+            <em>pointer</em> by the length of the [=fragment directive
             delimiter=] minus 1.
     - Step 3 (now step 4 after the above change) must begin with "Otherwise,"
   - In step 11 of this algorithm, add a new [=fragment directive state=]
@@ -209,7 +209,7 @@ directive</dfn>.
 Amend the
 <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">
 create and initialize a Document object</a> steps to store and remove the
-[=fragment directive=] from the a Document's URL.
+[=fragment directive=] from the Document's [[DOM#concept-document-url|URL]].
 
 Replace steps 7 and 8 of this algorithm with:
 
@@ -288,10 +288,17 @@ invoke.
 </div>
 
 1. If any of the following conditions are true, return false.
-    * <em>window</em>'s parent field is non-null.
-    * <em>window</em>'s opener field is non-null.
-    * The document of the previous entry in <em>window</em>'s browsing context's
-        session history is equal to <em>window</em>'s document.
+    * <em>window</em>'s
+        <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-parent">parent</a>
+        field is non-null.
+    * <em>window</em>'s
+        <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-opener">opener</a>
+        field is non-null.
+    * The <a href="https://html.spec.whatwg.org/#document">Document</a> of the
+        [[HTML#latest-entry|latest entry]] in <em>window</em>'s
+        [[HTML#browsing-context|browsing context]]'s
+        [[HTML#session-history|session history]] is equal to <em>window</em>'s
+        document.
         <div class="note">
         That is, this is the result of a same document navigation
         </div>
@@ -311,7 +318,7 @@ Add the following steps to the beginning of the processing model for <a
 href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">The
 indicated part of the document</a>.
 
-1. Let <dfn>fragment directive string</dfn> be the document [=URL's fragment
+1. Let <em>fragment directive string</em> be the document [=URL's fragment
     directive=].
 2. Let <em>is user activated</em> be true if the current navigation was <a
     href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
@@ -322,25 +329,26 @@ indicated part of the document</a>.
     </div>
 3. If the result of [[#should-allow-text-fragment]] with the window of the
     document's browsing context and <em>is user activated</em> is true then:
-    1. If [[#find-a-target-text]] with [=fragment directive string=] returns
+    1. If [[#find-a-target-text]] with <em>fragment directive string</em> returns
         non-null, then the return value is the indicated part of the document;
         return.
 
 ### Find a target text ### {#find-a-target-text}
 
-To find the target text for a given string <dfn>fragment directive input</dfn>,
+To find the target text for a given string <em>fragment directive input</em>,
 the user agent must run these steps:
-1. If [=fragment directive input=] does not begin with the string "text=",
+1. If <em>fragment directive input</em> does not begin with the string "text=",
     then return null.
-2. Let <em>raw target text</em> be the substring of [=fragment directive input=]
+2. Let <em>raw target text</em> be the substring of <em>fragment directive input</em>
     starting at index 5.
     <div class="note">
-    This is the remainder of the [=fragment directive input=] following, but not
+    This is the remainder of the <em>fragment directive input</em> following, but not
     including, the "text=" prefix.
     </div>
 3. If <em>raw target text</em> is the empty string, return null.
-4. Let <em>tokens</em> be a list of strings that is the result of splitting the
-    string <em>raw target text</em> on commas.
+4. Let <em>tokens</em> be a [[INFRA#list|list]] of strings that is the result of
+    [[INFRA#split-on-commas|splitting a string on commas]] of <em>raw target
+    text</em>.
 5. Let <em>prefix</em> and <em>suffix</em> and <em>textEnd</em> be the empty
     string.
     <div class="note">
@@ -351,29 +359,31 @@ the user agent must run these steps:
 7. If the last character of <em>potential prefix</em> is U+002D (-), then:
     1. Set <em>prefix</em> to the result of removing the last character from
         <em>potential prefix</em>.
-    2. Remove the first item of the list <em>tokens</em>.
+    2. [[INFRA#list-remove|Remove]] the first item of the list <em>tokens</em>.
 8. Let <em>potential suffix</em> be the last item of <em>tokens</em>.
 9. If the first character of <em>potential suffix</em> is U+002D (-), then:
     1. Set <em>suffix</em> to the result of removing the first character from
         <em>potential suffix</em>.
-    2. Remove the last item of the list <em>tokens</em>.
-10. Assert: <em>tokens</em> has size 1 or <em>tokens</em> has size 2.
+    2. [[INFRA#list-remove|Remove]] the last item of the list <em>tokens</em>.
+10. Assert: <em>tokens</em> has [[INFRA#list-size|size]] 1 or <em>tokens</em>
+    has [[INFRA#list-size|size]] 2.
     <div class="note">
     Once the prefix and suffix are removed from tokens, tokens may either
     contain one item (textStart) or two items (textStart and textEnd).
     </div>
 11. Let <em>textStart</em> be the first item of <em>tokens</em>.
-12. If <em>tokens</em> has size 2, then let <em>textEnd</em> be the last item of
-    <em>tokens</em>.
+12. If <em>tokens</em> has [[INFRA#list-size|size]] 2, then let <em>textEnd</em>
+    be the last item of <em>tokens</em>.
     <div class="note">
     The strings prefix, textStart, textEnd, and suffix now contain the
     text directive parameters as defined in [[#syntax]].
     </div>
 13. Let <em>walker</em> be a
-    <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> equal to
-    <a href="https://dom.spec.whatwg.org/#dom-document-createtreewalker">Document.createTreeWalker()</a>.
-14. Let <em>position</em> be a position variable that indicates a text offset in
-    in <em>walker.currentNode.innerText</em>.
+    [[DOM#treewalker|TreeWalker]] equal to
+    [[DOM#dom-document-createtreewalker|Document.createTreeWalker()]].
+14. Let <em>position</em> be a [[INFRA#string-position-variable|position
+    variable]] that indicates a text offset in
+    <em>walker.currentNode.innerText</em>.
 15. If textEnd is the empty string, then:
     1. Let <em>match position</em> be the result of [[#find-match-with-context]]
         with input walker <em>walker</em>, search position <em>position</em>,
@@ -406,9 +416,8 @@ This algorithm has input <em>walker, search position, prefix, query,</em> and
 <em>suffix</em> and returns a text position that is the start of the match.
 </div>
 <div class="note">
-The input <em>walker</em> is a
-<a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> reference, not
-a copy, i.e. any modifications are performed on the caller's instance of
+The input <em>walker</em> is a [[DOM#treewalker|TreeWalker]] reference, not a
+copy, i.e. any modifications are performed on the caller's instance of
 <em>walker</em>.
 </div>
 
@@ -423,14 +432,16 @@ a copy, i.e. any modifications are performed on the caller's instance of
                 <em>text</em> from <em>search position</em> with [=current
                 locale=].
             2. If <em>search position</em> is null, then break.
-            3. Advance <em>search position</em> past any whitespace.
+            3. [[INFRA#skip-ascii-whitespace|Skip ASCII whitespace]] on
+                <em>search position</em>.
             4. If <em>search position</em> is at the end of <em>text</em>, then:
                 1. Perform [[#advance-walker-to-text]] on <em>walker</em>.
                 2. If <em>walker.currentNode</em> is null, then return null.
                 3. Set <em>text</em> to <em>walker.currentNode.innerText</em>.
                 4. Set <em>search position</em> to the beginning of
                     <em>text</em>.
-                5. Advance <em>search position</em> past any whitespace.
+                5. [[INFRA#skip-ascii-whitespace|Skip ASCII whitespace]] on
+                    <em>search position</em>.
             5. If the result of [[#next-word-bounded-instance]] of
                 <em>query</em> in <em>text</em> from <em>search position</em> 
                 with [=current locale=] does not start at <em>search
@@ -445,21 +456,23 @@ a copy, i.e. any modifications are performed on the caller's instance of
             instance of query.
             </div>
         3. If <em>search position</em> is null, then break.
-        4. Let <em>potential match position</em> be a position variable equal to
+        4. Let <em>potential match position</em> be a
+            [[INFRA#string-position-variable|position variable]] equal to
             <em>search position</em> minus the length of <em>query</em>.
         5. If <em>suffix</em> is the empty string, then return <em>potential
             match position</em>.
-        6. Advance <em>search position</em> past any whitespace.
+        6. [[INFRA#skip-ascii-whitespace|Skip ASCII whitespace]] on
+            <em>search position</em>.
         7. If <em>search position</em> is at the end of <em>text</em>, then:
-            1. Let <em>suffix_walker</em> be a
-                <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a>
+            1. Let <em>suffix_walker</em> be a [[DOM#treewalker|TreeWalker]]
                 that is a copy of <em>walker</em>.
             2. Perform [[#advance-walker-to-text]] on <em>suffix_walker</em>.
             3. If <em>suffix_walker.currentNode</em> is null, then return null.
             4. Set <em>text</em> to
                 <em>suffix_walker.currentNode.innerText</em>.
             5. Set <em>search position</em> to the beginning of <em>text</em>.
-            6. Advance <em>search position</em> past any whitespace.
+            6. [[INFRA#skip-ascii-whitespace|Skip ASCII whitespace]] on
+                <em>search position</em>.
         8. If the result of [[#next-word-bounded-instance]] of <em>suffix</em>
             in <em>text</em> from <em>search position</em> with [=current
             locale=] starts at <em>search position</em>, then return
@@ -473,9 +486,8 @@ of the <em>currentNode</em>.
 
 ### Advance a TreeWalker to the next text node ### {#advance-walker-to-text}
 <div class="note">
-The input <em>walker</em> is a
-<a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> reference, not
-a copy, i.e. any modifications are performed on the caller's instance of
+The input <em>walker</em> is a [[DOM#treewalker|TreeWalker]] reference, not a
+copy, i.e. any modifications are performed on the caller's instance of
 <em>walker</em>.
 </div>
 
@@ -554,8 +566,8 @@ The UA must not visually indicate any provided context terms.
 ## Feature Detectability ## {#feature-detectability}
 
 For feature detectability, we propose adding a new FragmentDirective interface
-that is exposed via window.location.fragmentDirective if the UA supports the
-feature.
+that is exposed via <code>window.location.fragmentDirective</code> if the UA
+supports the feature.
 
 <pre class='idl'>
 interface FragmentDirective {
@@ -564,7 +576,7 @@ interface FragmentDirective {
 
 We amend
 <a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface">The
-Location Interface</a> to include a fragmentDirective property:
+Location Interface</a> to include a <code>fragmentDirective</code> property:
 
 <pre class='idl'>
 interface Location {

--- a/index.html
+++ b/index.html
@@ -1659,14 +1659,9 @@ the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fra
 step 2:</p>
        <ul>
         <li data-md>
-<<<<<<< HEAD
-         <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+003A (:) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> begins with the two consecutive code points U+007E (~) and U+003A
-(:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <a href="https://url.spec.whatwg.org/#pointer">URL Standard §pointer</a> by the length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive
-delimiter</a> minus 1.</p>
-=======
          <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is U+003A (:) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> begins with the two consecutive code points U+007E (~) and U+003A
-(:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <a href="https://url.spec.whatwg.org/#c">c</a> by the length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive delimiter</a> minus 1.</p>
->>>>>>> Add shortnames to links in spec amendment sections.
+(:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <a href="https://url.spec.whatwg.org/#pointer">pointer</a> by the length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive
+delimiter</a> minus 1.</p>
        </ul>
       <li data-md>
        <p>Step 3 (now step 4 after the above change) must begin with "Otherwise,"</p>

--- a/index.html
+++ b/index.html
@@ -1645,18 +1645,19 @@ process the resource. It is initially null. </em></p>
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> is the part of the URL fragment that follows
 the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive delimiter</a>.</p>
-   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> is part of the URL fragment. This means it must always
-  appear after a U+0023 (#) code point in a URL. </div>
+   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> is part of the URL fragment. This means it must
+  always appear after a U+0023 (#) code point in a URL. </div>
    <div class="example" id="example-aa58e32d"><a class="self-link" href="#example-aa58e32d"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a> to a URL like https://example.com, a fragment
   must first be appended to the URL: https://example.com#:~:text=foo. </div>
    <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> in a URL:</p>
    <ul>
     <li data-md>
-     <p>In step 11 of this algorithm, amend the <a href="https://url.spec.whatwg.org/#fragment-state">fragment state</a> case:</p>
+     <p>In step 11 of this algorithm, amend the <a href="https://url.spec.whatwg.org/#fragment-state">fragment
+state</a> case:</p>
      <ul>
       <li data-md>
-       <p>In the inner switch on <a href="https://url.spec.whatwg.org/#c">c</a>, in the Otherwise case, add a step after
-step 2:</p>
+       <p>In the inner switch on <a href="https://url.spec.whatwg.org/#c">c</a>, in the Otherwise case, add a step
+after step 2:</p>
        <ul>
         <li data-md>
          <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is U+003A (:) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> begins with the two consecutive code points U+007E (~) and U+003A
@@ -1681,20 +1682,21 @@ delimiter</a> minus 1.</p>
          <p>Otherwise:</p>
          <ol>
           <li data-md>
-           <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is not a URL code point and not U+0025 (%), validation
-error.</p>
+           <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is not a URL code point and not U+0025 (%),
+validation error.</p>
           <li data-md>
            <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is U+0025 (%) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> does not start with two ASCII hex digits, validation error.</p>
           <li data-md>
-           <p>UTF-8 percent encode <a href="https://url.spec.whatwg.org/#c">c</a> using the fragment percent-encode set
-and append the result to <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive">URL’s fragment directive</a>.</p>
+           <p>UTF-8 percent encode <a href="https://url.spec.whatwg.org/#c">c</a> using the fragment
+percent-encode set and append the result to <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive">URL’s fragment
+directive</a>.</p>
          </ol>
        </ul>
      </ul>
    </ul>
-   <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive delimiter</a>.
-  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> includes all characters that follow, but not including,
-  the delimiter. </div>
+   <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive
+  delimiter</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> includes all characters that follow,
+  but not including, the delimiter. </div>
    <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
 the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> is the string
 "text=foo". </div>
@@ -1702,8 +1704,8 @@ the fragment is the string "test" and the <a data-link-type="dfn" href="#fragmen
    <p>Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer </a> steps by inserting a step after step 7:</p>
    <ol start="8">
     <li data-md>
-     <p>If the <em>exclude fragment flag</em> is unset and <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive①">URL’s fragment directive</a> is
-non-null:</p>
+     <p>If the <em>exclude fragment flag</em> is unset and <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive①">URL’s fragment
+directive</a> is non-null:</p>
      <ol>
       <li data-md>
        <p>If <a href="https://url.spec.whatwg.org/#concept-url-fragment">url’s fragment</a> is null, append U+0023 (#)
@@ -1744,11 +1746,34 @@ directive types to be added and combined. </div>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> that
 enables specifying a piece of text on the page, that matches the production:</p>
    <dl>
-     <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt> <dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters">TextDirectiveParameters</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring">TextMatchString</a> ("," <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring①">TextMatchString</a>)? ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix">TextDirectivePrefix</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring②">TextMatchString</a> "-"</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix">TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring③">TextMatchString</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchstring">TextMatchString</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar">TextMatchChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchchar">TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code> 
+     <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt><dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></dd></code> 
+    <p><code></code></p>
+    <dt><code><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters">TextDirectiveParameters</dfn> ::=</code>
+    <dd><code> (<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring">TextMatchString</a> ("," <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring①">TextMatchString</a>)?
+("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)?</code>
+    <p></p>
+    <p><code></code></p>
+    <dt><code><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix">TextDirectivePrefix</dfn> ::=</code>
+    <dd><code><a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring②">TextMatchString</a> "-"</code>
+    <p></p>
+    <p><code></code></p>
+    <dt><code><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix">TextDirectiveSuffix</dfn> ::=</code>
+    <dd><code>"-" <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring③">TextMatchString</a></code>
+    <p></p>
+    <p><code></code></p>
+    <dt><code><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchstring">TextMatchString</dfn> ::=</code>
+    <dd><code>(<a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar">TextMatchChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</code>
+    <p></p>
+    <p><code></code></p>
+    <dt><code><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchchar">TextMatchChar</dfn> ::=</code>
+    <dd><code>[a-zA-Z0-9] | "!" | "$" | "'" |
+"(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</code>
+    <code> </code>
+    <p></p>
     <div class="note" role="note"> A <a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar①">TextMatchChar</a> may be any <a href="https://url.spec.whatwg.org/#url-code-points">URL code point</a> that
-is not explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a> syntax, that is "&amp;", "-", and ",",
-which must be percent-encoded. </div>
-     <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar">PercentEncodedChar</dfn> ::=</dt> <dd>"%" [a-zA-Z0-9]+</dd></code> 
+is not explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a> syntax, that is "&amp;", "-", and
+",", which must be percent-encoded. </div>
+     <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar">PercentEncodedChar</dfn> ::=</dt><dd>"%" [a-zA-Z0-9]+</dd></code> 
    </dl>
    <h3 class="heading settled" data-level="2.3" id="allow-text-fragment-directives"><span class="secno">2.3. </span><span class="content">Security and Privacy</span><a class="self-link" href="#allow-text-fragment-directives"></a></h3>
    <h4 class="heading settled" data-level="2.3.1" id="motivation"><span class="secno">2.3.1. </span><span class="content">Motivation</span><a class="self-link" href="#motivation"></a></h4>
@@ -1776,9 +1801,9 @@ invoke. </div>
      <p>If any of the following conditions are true, return false.</p>
      <ul>
       <li data-md>
-       <p><em>window</em>’s <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-parent">parent</a> field is non-null.</p>
+       <p><em>window</em>’s <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-parent"> parent</a> field is non-null.</p>
       <li data-md>
-       <p><em>window</em>’s <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-opener">opener</a> field is non-null.</p>
+       <p><em>window</em>’s <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-opener"> opener</a> field is non-null.</p>
       <li data-md>
        <p>The <a href="https://html.spec.whatwg.org/#document">Document</a> of the <a href="https://html.spec.whatwg.org/multipage/#latest-entry">latest entry</a> in <em>window</em>’s <a href="https://html.spec.whatwg.org/multipage/#browsing-context">browsing context</a>'s <a href="https://html.spec.whatwg.org/multipage/#session-history">session history</a> is equal to <em>window</em>’s
 document.</p>
@@ -1790,11 +1815,10 @@ document.</p>
      <p>Otherwise, return true.</p>
    </ol>
    <h3 class="heading settled" data-level="2.4" id="navigating-to-text-fragment"><span class="secno">2.4. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
-   <div class="note" role="note"> The scroll to text specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.8.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑥">text fragment directive</a> is present
-and a match is found in the page, the text fragment takes precedent over the
-element fragment as the indicated part of the document. </div>
-   <p>Add the following steps to the beginning of the processing model for <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">The
-indicated part of the document</a>.</p>
+   <div class="note" role="note"> The scroll to text specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.8.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑥">text fragment directive</a> is
+present and a match is found in the page, the text fragment takes precedent over
+the element fragment as the indicated part of the document. </div>
+   <p>Add the following steps to the beginning of the processing model for <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document"> The indicated part of the document</a>.</p>
    <ol>
     <li data-md>
      <p>Let <em>fragment directive string</em> be the document <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive⑤">URL’s fragment
@@ -1809,9 +1833,8 @@ activation triggering </div>
 document’s browsing context and <em>is user activated</em> is true then:</p>
      <ol>
       <li data-md>
-       <p>If <a href="#find-a-target-text">§ 2.4.1 Find a target text</a> with <em>fragment directive string</em> returns
-non-null, then the return value is the indicated part of the document;
-return.</p>
+       <p>If <a href="#find-a-target-text">§ 2.4.1 Find a target text</a> with <em>fragment directive string</em> returns non-null, then the return value is the indicated part of the
+document; return.</p>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="2.4.1" id="find-a-target-text"><span class="secno">2.4.1. </span><span class="content">Find a target text</span><a class="self-link" href="#find-a-target-text"></a></h4>
@@ -1822,9 +1845,10 @@ the user agent must run these steps:</p>
      <p>If <em>fragment directive input</em> does not begin with the string "text=",
 then return null.</p>
     <li data-md>
-     <p>Let <em>raw target text</em> be the substring of <em>fragment directive input</em> starting at index 5.</p>
-     <div class="note" role="note"> This is the remainder of the <em>fragment directive input</em> following, but not
-including, the "text=" prefix. </div>
+     <p>Let <em>raw target text</em> be the substring of <em>fragment directive
+input</em> starting at index 5.</p>
+     <div class="note" role="note"> This is the remainder of the <em>fragment directive input</em> following,
+but not including, the "text=" prefix. </div>
     <li data-md>
      <p>If <em>raw target text</em> is the empty string, return null.</p>
     <li data-md>
@@ -1998,7 +2022,7 @@ copy, i.e. any modifications are performed on the caller’s instance of <em>wal
      <p>While the input <em>walker.currentNode</em> is not null and <em>walker.currentNode</em> is not a text node:</p>
      <ol>
       <li data-md>
-       <p>Advance the current node by calling <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode">walker.nextNode()</a></p>
+       <p>Advance the current node by calling <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode"> walker.nextNode()</a></p>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="2.4.4" id="next-word-bounded-instance"><span class="secno">2.4.4. </span><span class="content">Find the next word bounded instance</span><a class="self-link" href="#next-word-bounded-instance"></a></h4>
@@ -2027,9 +2051,9 @@ boundary in <em>text</em> after <em>range</em>.</p>
         <p> Limiting matching to word boundaries is one of the mitigations to
     limit cross-origin information leakage. A word boundary is as
     defined in the <a href="http://www.unicode.org/reports/tr29/#Word_Boundaries">Unicode
-    text segmentation annex</a>. The <a href="http://www.unicode.org/reports/tr29/#Default_Word_Boundaries"> Default Word Boundary Specification</a> defines a default set of what
-    constitutes a word boundary, but as the specification mentions, a
-    more sophisticated algorithm should be used based on the <em>locale</em>. </p>
+    text segmentation annex</a>. The <a href="http://www.unicode.org/reports/tr29/#Default_Word_Boundaries"> Default Word Boundary Specification</a> defines a default set of
+    what constitutes a word boundary, but as the specification mentions,
+    a more sophisticated algorithm should be used based on the <em>locale</em>. </p>
         <p> Dictionary-based word bounding should take specific care in
     locales without a word-separating character (e.g. space). In
     those cases, and where the alphabet contains fewer than 100
@@ -2044,8 +2068,7 @@ bound</em> immediately follows <em>range</em>, then return <em>range</em>.</p>
      <p>Return <em>null</em>.</p>
    </ol>
    <h3 class="heading settled" data-level="2.5" id="indicating-the-text-match"><span class="secno">2.5. </span><span class="content">Indicating The Text Match</span><a class="self-link" href="#indicating-the-text-match"></a></h3>
-   <p>In addition to scrolling the text fragment into view as part of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">Try
-To Scroll To The Fragment</a> steps, the UA should visually indicate the
+   <p>In addition to scrolling the text fragment into view as part of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment"> Try To Scroll To The Fragment</a> steps, the UA should visually indicate the
 matched text in some way such that the user is made aware of the text match.</p>
    <p>The UA should provide to the user some method of dismissing the match, such
 that the matched text no longer appears visually indicated.</p>
@@ -2061,8 +2084,7 @@ supports the feature.</p>
 <pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="fragmentdirective①"><code><c- g>FragmentDirective</c-></code></dfn> {
 };
 </pre>
-   <p>We amend <a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface">The
-Location Interface</a> to include a fragmentDirective property:</p>
+   <p>We amend <a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface"> The Location Interface</a> to include a <code>fragmentDirective</code> property:</p>
 <pre class="idl highlight def"><c- b>interface</c-> <dfn class="idl-code" data-dfn-type="interface" data-export id="location"><code><c- g>Location</c-></code><a class="self-link" href="#location"></a></dfn> {
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective①" id="ref-for-fragmentdirective①"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-location-fragmentdirective"></a></dfn>;
 };
@@ -2070,8 +2092,9 @@ Location Interface</a> to include a fragmentDirective property:</p>
    <h2 class="heading settled" data-level="3" id="generating-text-fragment-directives"><span class="secno">3. </span><span class="content">Generating Text Fragment Directives</span><a class="self-link" href="#generating-text-fragment-directives"></a></h2>
    <div class="note" role="note"> This section is non-normative. </div>
    <p>This section contains recommendations for UAs automatically generating URLs
-with a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑦">text fragment directive</a>. These recommendations aren’t normative but are
-provided to ensure generated URLs result in maximally stable and usable URLs.</p>
+with a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑦">text fragment directive</a>. These recommendations aren’t normative but
+are provided to ensure generated URLs result in maximally stable and usable
+URLs.</p>
    <h3 class="heading settled" data-level="3.1" id="prefer-exact-matching-to-range-based"><span class="secno">3.1. </span><span class="content">Prefer Exact Matching To Range-based</span><a class="self-link" href="#prefer-exact-matching-to-range-based"></a></h3>
    <p>The match text can be provided either as an exact string "text=foo%20bar%20baz"
 or as a range "text=foo,bar".</p>
@@ -2104,12 +2127,12 @@ encoded using an exact match. Above this limit, the UA should encode the string
 as a range-based match.</p>
    <div class="note" role="note"> TODO:  Can we determine the above limit in some more objective way? </div>
    <h3 class="heading settled" data-level="3.2" id="use-context-only-when-necessary"><span class="secno">3.2. </span><span class="content">Use Context Only When Necessary</span><a class="self-link" href="#use-context-only-when-necessary"></a></h3>
-   <p>Context terms allow the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑧">text fragment directive</a> to disambiguate text snippets
-on a page. However, their use can make the URL more brittle in some cases.
-Often, the desired string will start or end at an element boundary. The context
-will therefore exist in an adjacent element. Changes to the page structure
-could invalidate the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑨">text fragment directive</a> since the context and match text
-may no longer appear to be adjacent.</p>
+   <p>Context terms allow the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑧">text fragment directive</a> to disambiguate text
+snippets on a page. However, their use can make the URL more brittle in some
+cases. Often, the desired string will start or end at an element boundary. The
+context will therefore exist in an adjacent element. Changes to the page
+structure could invalidate the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑨">text fragment directive</a> since the context and
+match text may no longer appear to be adjacent.</p>
    <div class="example" id="example-735b40dc">
     <a class="self-link" href="#example-735b40dc"></a> Suppose we wish to craft a URL for the following text: 
 <pre>&lt;div class="section">HEADER&lt;/div>

--- a/index.html
+++ b/index.html
@@ -1652,16 +1652,21 @@ the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fra
    <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> in a URL:</p>
    <ul>
     <li data-md>
-     <p>In step 11 of this algorithm, amend the <a href="https://url.spec.whatwg.org/#fragment-state">URL Standard §fragment-state</a> case:</p>
+     <p>In step 11 of this algorithm, amend the <a href="https://url.spec.whatwg.org/#fragment-state">fragment state</a> case:</p>
      <ul>
       <li data-md>
-       <p>In the inner switch on <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a>, in the Otherwise case, add a step after
+       <p>In the inner switch on <a href="https://url.spec.whatwg.org/#c">c</a>, in the Otherwise case, add a step after
 step 2:</p>
        <ul>
         <li data-md>
+<<<<<<< HEAD
          <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+003A (:) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> begins with the two consecutive code points U+007E (~) and U+003A
 (:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <a href="https://url.spec.whatwg.org/#pointer">URL Standard §pointer</a> by the length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive
 delimiter</a> minus 1.</p>
+=======
+         <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is U+003A (:) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> begins with the two consecutive code points U+007E (~) and U+003A
+(:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <a href="https://url.spec.whatwg.org/#c">c</a> by the length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive delimiter</a> minus 1.</p>
+>>>>>>> Add shortnames to links in spec amendment sections.
        </ul>
       <li data-md>
        <p>Step 3 (now step 4 after the above change) must begin with "Otherwise,"</p>
@@ -1671,7 +1676,7 @@ delimiter</a> minus 1.</p>
      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-state">fragment directive state</dfn>:</p>
      <ul>
       <li data-md>
-       <p>Switching on <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a>:</p>
+       <p>Switching on <a href="https://url.spec.whatwg.org/#c">c</a>:</p>
        <ul>
         <li data-md>
          <p>The EOF code point: Do nothing</p>
@@ -1681,12 +1686,12 @@ delimiter</a> minus 1.</p>
          <p>Otherwise:</p>
          <ol>
           <li data-md>
-           <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is not a URL code point and not U+0025 (%), validation
+           <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is not a URL code point and not U+0025 (%), validation
 error.</p>
           <li data-md>
-           <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+0025 (%) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> does not start with two ASCII hex digits, validation error.</p>
+           <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is U+0025 (%) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> does not start with two ASCII hex digits, validation error.</p>
           <li data-md>
-           <p>UTF-8 percent encode <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> using the fragment percent-encode set
+           <p>UTF-8 percent encode <a href="https://url.spec.whatwg.org/#c">c</a> using the fragment percent-encode set
 and append the result to <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive">URL’s fragment directive</a>.</p>
          </ol>
        </ul>

--- a/index.html
+++ b/index.html
@@ -1781,8 +1781,9 @@ invoke. </div>
       <li data-md>
        <p><em>window</em>’s opener field is non-null.</p>
       <li data-md>
-       <p>The document of the previous entry in <em>window</em>’s browsing context’s session history is equal to <em>window</em>’s document.</p>
-       <div class="note" role="note">That is, this is the result of a same document navigation</div>
+       <p>The document of the previous entry in <em>window</em>’s browsing context’s
+session history is equal to <em>window</em>’s document.</p>
+       <div class="note" role="note"> That is, this is the result of a same document navigation </div>
       <li data-md>
        <p><em>is user triggered</em> is false.</p>
      </ul>
@@ -1799,18 +1800,18 @@ indicated part of the document</a>.</p>
     <li data-md>
      <p>Let <em>fragment directive</em> be the document URL’s <a href="#fragment-directive" id="ref-for-fragment-directive②">fragment directive</a>.</p>
     <li data-md>
-     <p>Let <em>is user activated</em> be true if the current navigation was <a href="https://html.spec.whatwg.org/#triggered-by-user-activation">triggered by
-   user activation</a></p>
+     <p>Let <em>is user activated</em> be true if the current navigation was <a href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
+by user activation</a></p>
      <div class="note" role="note"> TODO: This might need an additional flag somewhere to track the user
-  activation triggering </div>
+activation triggering </div>
     <li data-md>
      <p>If the result of <a href="#should-allow-text-fragment">§ 2.3.2 Should Allow Text Fragment</a> with the window of the
-   document’s browsing context and <em>is user activated</em> is true then:</p>
+document’s browsing context and <em>is user activated</em> is true then:</p>
      <ol>
       <li data-md>
        <p>If <a href="#find-a-target-text">§ 2.4.1 Find a target text</a> with <em>fragment directive</em> returns
-   non-null, then the return value is the indicated part of the document;
-   return.</p>
+non-null, then the return value is the indicated part of the document;
+return.</p>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="2.4.1" id="find-a-target-text"><span class="secno">2.4.1. </span><span class="content">Find a target text</span><a class="self-link" href="#find-a-target-text"></a></h4>

--- a/index.html
+++ b/index.html
@@ -1638,29 +1638,30 @@ introducing breaking changes to existing content. Potential examples could be:
 translation-hints or enabling accessibility features.</p>
    <h4 class="heading settled" data-level="2.2.1" id="parsing-the-fragment-directive"><span class="secno">2.2.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
    <p>To the definition of a <a href="https://url.spec.whatwg.org/#concept-url"> URL record</a>, add:</p>
-   <p><em> A URL’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> is either null or an ASCII string holding data used
-by the UA to process the resource. It is initially null </em></p>
+   <p><em> A <a href="https://url.spec.whatwg.org/#concept-url">URL</a>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="URL’s fragment directive" data-noexport id="urls-fragment-directive">fragment
+directive</dfn> is either null or an ASCII string holding data used by the UA to
+process the resource. It is initially null. </em></p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-delimiter">fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> is the part of the URL fragment that follows
 the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive delimiter</a>.</p>
-   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a> is part of the URL fragment. This means it must always
+   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> is part of the URL fragment. This means it must always
   appear after a U+0023 (#) code point in a URL. </div>
-   <div class="example" id="example-aa58e32d"><a class="self-link" href="#example-aa58e32d"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> to a URL like https://example.com, a fragment
+   <div class="example" id="example-aa58e32d"><a class="self-link" href="#example-aa58e32d"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a> to a URL like https://example.com, a fragment
   must first be appended to the URL: https://example.com#:~:text=foo. </div>
-   <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> in a URL:</p>
+   <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> in a URL:</p>
    <ul>
     <li data-md>
-     <p>In step 11 of this algorithm, amend the <em>fragment state</em> case:</p>
+     <p>In step 11 of this algorithm, amend the <a href="https://url.spec.whatwg.org/#fragment-state">URL Standard §fragment-state</a> case:</p>
      <ul>
       <li data-md>
        <p>In the inner switch on <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a>, in the Otherwise case, add a step after
 step 2:</p>
        <ul>
         <li data-md>
-         <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+003A (:) and <em>remaining</em> begins with the two
-consecutive code points U+007E (~) and U+003A (:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <a href="https://url.spec.whatwg.org/#pointer">URL Standard §pointer</a> by the
-length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive delimiter</a> minus 1.</p>
+         <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+003A (:) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> begins with the two consecutive code points U+007E (~) and U+003A
+(:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <a href="https://url.spec.whatwg.org/#pointer">URL Standard §pointer</a> by the length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive
+delimiter</a> minus 1.</p>
        </ul>
       <li data-md>
        <p>Step 3 (now step 4 after the above change) must begin with "Otherwise,"</p>
@@ -1683,38 +1684,38 @@ length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="r
            <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is not a URL code point and not U+0025 (%), validation
 error.</p>
           <li data-md>
-           <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+0025 (%) and <em>remaining</em> does not start with
-two ASCII hex digits, validation error.</p>
+           <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+0025 (%) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> does not start with two ASCII hex digits, validation error.</p>
           <li data-md>
            <p>UTF-8 percent encode <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> using the fragment percent-encode set
-and append the result to <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a>.</p>
+and append the result to <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive">URL’s fragment directive</a>.</p>
          </ol>
        </ul>
      </ul>
    </ul>
    <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive delimiter</a>.
-  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> includes all characters that follow, but not including,
+  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> includes all characters that follow, but not including,
   the delimiter. </div>
    <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
-the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a> is the string
+the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> is the string
 "text=foo". </div>
    <h4 class="heading settled" data-level="2.2.2" id="serializing-the-fragment-directive"><span class="secno">2.2.2. </span><span class="content">Serializing the fragment directive</span><a class="self-link" href="#serializing-the-fragment-directive"></a></h4>
    <p>Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer </a> steps by inserting a step after step 7:</p>
    <ol start="8">
     <li data-md>
-     <p>If the <em>exclude fragment flag</em> is unset and <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> is
+     <p>If the <em>exclude fragment flag</em> is unset and <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive①">URL’s fragment directive</a> is
 non-null:</p>
      <ol>
       <li data-md>
        <p>If <em>url’s fragment</em> is null, append U+0023 (#) to <em>output</em>.</p>
       <li data-md>
-       <p>Append ":~:", followed by <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a>, to <em>output</em>.</p>
+       <p>Append ":~:", followed by <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive②">URL’s fragment directive</a>, to <em>output</em>.</p>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="2.2.3" id="processing-the-fragment-directive"><span class="secno">2.2.3. </span><span class="content">Processing the fragment directive</span><a class="self-link" href="#processing-the-fragment-directive"></a></h4>
    <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:</p>
-   <p><em> Each document has an associated <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a>. </em></p>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment directive</a> from the a Document’s URL.</p>
+   <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Document’s fragment directive" data-noexport id="documents-fragment-directive">fragment
+directive</dfn>. </em></p>
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> from the a Document’s URL.</p>
    <p>Replace steps 7 and 8 of this algorithm with:</p>
    <ol start="7">
     <li data-md>
@@ -1725,22 +1726,22 @@ current URL</em>.</p>
     <li data-md>
      <p>Otherwise, set <em>url</em> to <em>response’s URL</em>.</p>
     <li data-md>
-     <p>Set <em>document’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑤">fragment directive</a> be <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑥">fragment directive</a>.  (Note: this is stored on the document but not
-web-exposed)</p>
+     <p>Set <a data-link-type="dfn" href="#documents-fragment-directive" id="ref-for-documents-fragment-directive">Document’s fragment directive</a> to <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive③">URL’s fragment directive</a>.
+(Note: this is stored on the document but not web-exposed)</p>
     <li data-md>
-     <p>Set <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑦">fragment directive</a> to null.</p>
+     <p>Set <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive④">URL’s fragment directive</a> to null.</p>
     <li data-md>
      <p>Set the <em>document’s url</em> to be <em>url</em>.</p>
    </ol>
    <h4 class="heading settled" data-level="2.2.4" id="fragment-directive-grammar"><span class="secno">2.2.4. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
     A <dfn data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive<a class="self-link" href="#valid-fragment-directive"></a></dfn> is a sequence of characters that appears
-in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑧">fragment directive</a> that matches the production: 
+in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a> that matches the production: 
    <dl> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirective">FragmentDirective</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> ("&amp;" <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a>)*</dd></code> </dl>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective">FragmentDirective</a> may contain multiple directives split by the "&amp;"
 character. Currently this means we allow multiple text directives to enable
 multiple indicated strings in the page, but this also allows for future
 directive types to be added and combined. </div>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑨">fragment directive</a> that
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> that
 enables specifying a piece of text on the page, that matches the production:</p>
    <dl>
      <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt> <dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters">TextDirectiveParameters</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring">TextMatchString</a> ("," <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring①">TextMatchString</a>)? ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix">TextDirectivePrefix</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring②">TextMatchString</a> "-"</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix">TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring③">TextMatchString</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchstring">TextMatchString</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar">TextMatchChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchchar">TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code> 
@@ -1796,7 +1797,7 @@ element fragment as the indicated part of the document. </div>
 indicated part of the document</a>.</p>
    <ol>
     <li data-md>
-     <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-string">fragment directive string</dfn> be the document URL’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive②⓪">fragment
+     <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-string">fragment directive string</dfn> be the document <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive⑤">URL’s fragment
 directive</a>.</p>
     <li data-md>
      <p>Let <em>is user activated</em> be true if the current navigation was <a href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
@@ -2315,6 +2316,7 @@ manipulations
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#current-locale">current locale</a><span>, in §2.4.2</span>
+   <li><a href="#documents-fragment-directive">Document’s fragment directive</a><span>, in §2.2.3</span>
    <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §2.6</span>
    <li><a href="#fragment-directive">fragment directive</a><span>, in §2.2.1</span>
    <li>
@@ -2336,6 +2338,7 @@ manipulations
    <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §2.2.4</span>
    <li><a href="#textmatchchar">TextMatchChar</a><span>, in §2.2.4</span>
    <li><a href="#textmatchstring">TextMatchString</a><span>, in §2.2.4</span>
+   <li><a href="#urls-fragment-directive">URL’s fragment directive</a><span>, in §2.2.1</span>
    <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §2.2.4</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -2353,6 +2356,15 @@ manipulations
 };
 
 </pre>
+  <aside class="dfn-panel" data-for="urls-fragment-directive">
+   <b><a href="#urls-fragment-directive">#urls-fragment-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-urls-fragment-directive">2.2.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-urls-fragment-directive①">2.2.2. Serializing the fragment directive</a> <a href="#ref-for-urls-fragment-directive②">(2)</a>
+    <li><a href="#ref-for-urls-fragment-directive③">2.2.3. Processing the fragment directive</a> <a href="#ref-for-urls-fragment-directive④">(2)</a>
+    <li><a href="#ref-for-urls-fragment-directive⑤">2.4. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="fragment-directive-delimiter">
    <b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
    <ul>
@@ -2364,17 +2376,21 @@ manipulations
    <ul>
     <li><a href="#ref-for-fragment-directive">2.1. Syntax</a>
     <li><a href="#ref-for-fragment-directive①">2.2. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a>
-    <li><a href="#ref-for-fragment-directive④">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a> <a href="#ref-for-fragment-directive⑨">(6)</a> <a href="#ref-for-fragment-directive①⓪">(7)</a>
-    <li><a href="#ref-for-fragment-directive①①">2.2.2. Serializing the fragment directive</a> <a href="#ref-for-fragment-directive①②">(2)</a>
-    <li><a href="#ref-for-fragment-directive①③">2.2.3. Processing the fragment directive</a> <a href="#ref-for-fragment-directive①④">(2)</a> <a href="#ref-for-fragment-directive①⑤">(3)</a> <a href="#ref-for-fragment-directive①⑥">(4)</a> <a href="#ref-for-fragment-directive①⑦">(5)</a>
-    <li><a href="#ref-for-fragment-directive①⑧">2.2.4. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①⑨">(2)</a>
-    <li><a href="#ref-for-fragment-directive②⓪">2.4. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-fragment-directive④">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a>
+    <li><a href="#ref-for-fragment-directive⑨">2.2.3. Processing the fragment directive</a>
+    <li><a href="#ref-for-fragment-directive①⓪">2.2.4. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragment-directive-state">
    <b><a href="#fragment-directive-state">#fragment-directive-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-directive-state">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive-state①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="documents-fragment-directive">
+   <b><a href="#documents-fragment-directive">#documents-fragment-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-documents-fragment-directive">2.2.3. Processing the fragment directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragmentdirective">

--- a/index.html
+++ b/index.html
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-21">21 October 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-22">22 October 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1654,12 +1654,12 @@ the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fra
      <p>In step 11 of this algorithm, amend the <em>fragment state</em> case:</p>
      <ul>
       <li data-md>
-       <p>In the inner switch on <em>c</em>, in the Otherwise case, add a step after
+       <p>In the inner switch on <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a>, in the Otherwise case, add a step after
 step 2:</p>
        <ul>
         <li data-md>
-         <p>If <em>c</em> is U+003A (:) and <em>remaining</em> begins with the two
-consecutive code points U+007E (~) and U+003A (:), set state to <em>fragment-directive state</em>. Increase <em>pointer</em> by the
+         <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+003A (:) and <em>remaining</em> begins with the two
+consecutive code points U+007E (~) and U+003A (:), set state to <em>fragment-directive state</em>. Increment <a href="https://url.spec.whatwg.org/#pointer">URL Standard §pointer</a> by the
 length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive delimiter</a> minus 1.</p>
        </ul>
       <li data-md>
@@ -1670,7 +1670,7 @@ length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="r
      <p><em>fragment-directive state</em>:</p>
      <ul>
       <li data-md>
-       <p>Switching on <em>c</em>:</p>
+       <p>Switching on <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a>:</p>
        <ul>
         <li data-md>
          <p>The EOF code point: Do nothing</p>
@@ -1680,13 +1680,13 @@ length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="r
          <p>Otherwise:</p>
          <ol>
           <li data-md>
-           <p>If <em>c</em> is not a URL code point and not U+0025 (%), validation
+           <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is not a URL code point and not U+0025 (%), validation
 error.</p>
           <li data-md>
-           <p>If <em>c</em> is U+0025 (%) and <em>remaining</em> does not start with
+           <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+0025 (%) and <em>remaining</em> does not start with
 two ASCII hex digits, validation error.</p>
           <li data-md>
-           <p>UTF-8 percent encode <em>c</em> using the fragment percent-encode set
+           <p>UTF-8 percent encode <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> using the fragment percent-encode set
 and append the result to <em>url’s fragment-directive</em>.</p>
          </ol>
        </ul>

--- a/index.html
+++ b/index.html
@@ -1585,7 +1585,7 @@ the receiver loses the context of the page.
    <h2 class="heading settled" data-level="2" id="description"><span class="secno">2. </span><span class="content">Description</span><a class="self-link" href="#description"></a></h2>
    <h3 class="heading settled" data-level="2.1" id="syntax"><span class="secno">2.1. </span><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
    <div class="note" role="note">This section is non-normative</div>
-   <p>A <a data-link-type="dfn" href="#valid-text-directive" id="ref-for-valid-text-directive">valid text directive</a> is specified in the fragment directive (see <a href="#the-fragment-directive">§ 2.2 The Fragment Directive</a>) with the following format:</p>
+   <p>A <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive">text fragment directive</a> is specified in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive">fragment directive</a> (see <a href="#the-fragment-directive">§ 2.2 The Fragment Directive</a>) with the following format:</p>
 <pre>#:~:text=[prefix-,]textStart[,textEnd][,-suffix]
           context  |-------match-----|  context
 </pre>
@@ -1627,7 +1627,7 @@ to "an example" in "this is an example text fragment", but not match to "an
 example" in "here is an example text". </div>
    <h3 class="heading settled" data-level="2.2" id="the-fragment-directive"><span class="secno">2.2. </span><span class="content">The Fragment Directive</span><a class="self-link" href="#the-fragment-directive"></a></h3>
     To avoid compatibility issues with usage of existing URL fragments, this spec
-introduces the <em>fragment directive</em>. The fragment directive is a portion
+introduces the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①">fragment directive</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive②">fragment directive</a> is a portion
 of the URL fragment delimited by the code sequence <code>:~:</code>. It is
 reserved for UA instructions, such as text=, and is stripped from the URL
 during loading so that author scripts can’t directly interact with it. 
@@ -1648,7 +1648,7 @@ the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fra
   appear after a U+0023 (#) code point in a URL. </div>
    <div class="example" id="example-8a44ecf3"><a class="self-link" href="#example-8a44ecf3"></a> To add a fragment-directive to a URL like https://example.com, a fragment
   must first be appended to the URL: https://example.com#:~:text=foo. </div>
-   <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse fragment directives in a URL:</p>
+   <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive③">fragment directive</a> in a URL:</p>
    <ul>
     <li data-md>
      <p>In step 11 of this algorithm, amend the <em>fragment state</em> case:</p>
@@ -1693,7 +1693,7 @@ and append the result to <em>url’s fragment-directive</em>.</p>
      </ul>
    </ul>
    <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive delimiter</a>.
-  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive">fragment directive</a> includes all characters that follow, but not including,
+  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> includes all characters that follow, but not including,
   the delimiter. </div>
    <div class="example" id="example-cac370ee"><a class="self-link" href="#example-cac370ee"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
 the fragment is the string "test" and the fragment-directive is the string
@@ -1713,9 +1713,8 @@ non-null:</p>
    </ol>
    <h4 class="heading settled" data-level="2.2.3" id="processing-the-fragment-directive"><span class="secno">2.2.3. </span><span class="content">Processing the fragment directive</span><a class="self-link" href="#processing-the-fragment-directive"></a></h4>
    <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:</p>
-   <p><em> Each document has an associated fragment directive. </em></p>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the
-fragment directive from the a Document’s URL.</p>
+   <p><em> Each document has an associated <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a>. </em></p>
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> from the a Document’s URL.</p>
    <p>Replace steps 7 and 8 of this algorithm with:</p>
    <ol start="7">
     <li data-md>
@@ -1736,14 +1735,14 @@ web-exposed)</p>
    </ol>
    <h4 class="heading settled" data-level="2.2.4" id="fragment-directive-grammar"><span class="secno">2.2.4. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
     A <dfn data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive<a class="self-link" href="#valid-fragment-directive"></a></dfn> is a sequence of characters that appears
-in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①">fragment directive</a> that matches the production: 
+in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> that matches the production: 
    <dl> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirective">FragmentDirective</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> ("&amp;" <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a>)*</dd></code> </dl>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective">FragmentDirective</a> may contain multiple directives split by the "&amp;"
 character. Currently this means we allow multiple text directives to enable
 multiple indicated strings in the page, but this also allows for future
 directive types to be added and combined. </div>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-text-directive">valid text directive</dfn> is one such directive, that matches the
-production:</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> that
+enables specifying a piece of text on the page, that matches the production:</p>
    <dl>
      <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt> <dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters">TextDirectiveParameters</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring">TextMatchString</a> ("," <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring①">TextMatchString</a>)? ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix">TextDirectivePrefix</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring②">TextMatchString</a> "-"</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix">TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring③">TextMatchString</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchstring">TextMatchString</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar">TextMatchChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchchar">TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code> 
     <div class="note" role="note"> A <a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar①">TextMatchChar</a> may be any <a href="https://url.spec.whatwg.org/#url-code-points">URL code point</a> that
@@ -1754,23 +1753,23 @@ which must be percent-encoded. </div>
    <h3 class="heading settled" data-level="2.3" id="allow-text-fragment-directives"><span class="secno">2.3. </span><span class="content">Security and Privacy</span><a class="self-link" href="#allow-text-fragment-directives"></a></h3>
    <h4 class="heading settled" data-level="2.3.1" id="motivation"><span class="secno">2.3.1. </span><span class="content">Motivation</span><a class="self-link" href="#motivation"></a></h4>
    <div class="note" role="note">This section is non-normative</div>
-   <p>Care must be taken when implementing text fragment directive so that it
+   <p>Care must be taken when implementing <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive①">text fragment directive</a> so that it
 cannot be used to exfiltrate information across origins. Scripts can navigate
-a page to a cross-origin URL with a text fragment directive.  If a malicious
+a page to a cross-origin URL with a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive②">text fragment directive</a>.  If a malicious
 actor can determine that a victim page scrolled after such a navigation, they
 can infer the existence of any text on the page.</p>
    <p>In addition, the user’s privacy should be ensured even from the destination
 origin.  Although scripts on that page can already learn a lot about a user’s
-actions, a text fragment directive can still contain sensitive information. For
-this reason, this specification provides no way for a page to extract the
+actions, a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive③">text fragment directive</a> can still contain sensitive information.
+For this reason, this specification provides no way for a page to extract the
 content of the text fragment anchor. User agents must not expose this
 information to the page.</p>
    <div class="example" id="example-9ced00a5"><a class="self-link" href="#example-9ced00a5"></a> A user visiting a page listing dozens of medical conditions may have gotten
-  there via a link with a text fragment directive containing a specific
+  there via a link with a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive④">text fragment directive</a> containing a specific
   condition. This information must not be shared with the page. </div>
    <h4 class="heading settled" data-level="2.3.2" id="should-allow-text-fragment"><span class="secno">2.3.2. </span><span class="content">Should Allow Text Fragment</span><a class="self-link" href="#should-allow-text-fragment"></a></h4>
    <div class="note" role="note"> This algorithm has input <em>window, is user triggered</em> and returns a
-boolean indicating whether a text fragment directive should be allowed to
+boolean indicating whether a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑤">text fragment directive</a> should be allowed to
 invoke. </div>
    <ol>
     <li data-md>
@@ -1791,14 +1790,15 @@ session history is equal to <em>window</em>’s document.</p>
      <p>Otherwise, return true.</p>
    </ol>
    <h3 class="heading settled" data-level="2.4" id="navigating-to-text-fragment"><span class="secno">2.4. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
-   <div class="note" role="note"> The scroll to text specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.8.9 Navigating to a fragment</a>. In summary, if a text fragment directive is present
+   <div class="note" role="note"> The scroll to text specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.8.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑥">text fragment directive</a> is present
 and a match is found in the page, the text fragment takes precedent over the
 element fragment as the indicated part of the document. </div>
    <p>Add the following steps to the beginning of the processing model for <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">The
 indicated part of the document</a>.</p>
    <ol>
     <li data-md>
-     <p>Let <em>fragment directive</em> be the document URL’s <a href="#fragment-directive" id="ref-for-fragment-directive②">fragment directive</a>.</p>
+     <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-string">fragment directive string</dfn> be the document URL’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment
+directive</a>.</p>
     <li data-md>
      <p>Let <em>is user activated</em> be true if the current navigation was <a href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
 by user activation</a></p>
@@ -1809,21 +1809,21 @@ activation triggering </div>
 document’s browsing context and <em>is user activated</em> is true then:</p>
      <ol>
       <li data-md>
-       <p>If <a href="#find-a-target-text">§ 2.4.1 Find a target text</a> with <em>fragment directive</em> returns
+       <p>If <a href="#find-a-target-text">§ 2.4.1 Find a target text</a> with <a data-link-type="dfn" href="#fragment-directive-string" id="ref-for-fragment-directive-string">fragment directive string</a> returns
 non-null, then the return value is the indicated part of the document;
 return.</p>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="2.4.1" id="find-a-target-text"><span class="secno">2.4.1. </span><span class="content">Find a target text</span><a class="self-link" href="#find-a-target-text"></a></h4>
-   <p>To find the target text for a given string <em>fragment directive</em>, the
-user agent must run these steps:</p>
+   <p>To find the target text for a given string <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-input">fragment directive input</dfn>,
+the user agent must run these steps:</p>
    <ol>
     <li data-md>
-     <p>If <em>fragment directive</em> does not begin with the string "text=",
+     <p>If <a data-link-type="dfn" href="#fragment-directive-input" id="ref-for-fragment-directive-input">fragment directive input</a> does not begin with the string "text=",
 then return null.</p>
     <li data-md>
-     <p>Let <em>raw target text</em> be the substring of <em>fragment directive</em> starting at index 5.</p>
-     <div class="note" role="note"> This is the remainder of the fragment directive following, but not
+     <p>Let <em>raw target text</em> be the substring of <a data-link-type="dfn" href="#fragment-directive-input" id="ref-for-fragment-directive-input①">fragment directive input</a> starting at index 5.</p>
+     <div class="note" role="note"> This is the remainder of the <a data-link-type="dfn" href="#fragment-directive-input" id="ref-for-fragment-directive-input②">fragment directive input</a> following, but not
 including, the "text=" prefix. </div>
     <li data-md>
      <p>If <em>raw target text</em> is the empty string, return null.</p>
@@ -2070,7 +2070,7 @@ Location Interface</a> to include a fragmentDirective property:</p>
    <h2 class="heading settled" data-level="3" id="generating-text-fragment-directives"><span class="secno">3. </span><span class="content">Generating Text Fragment Directives</span><a class="self-link" href="#generating-text-fragment-directives"></a></h2>
    <div class="note" role="note"> This section is non-normative. </div>
    <p>This section contains recommendations for UAs automatically generating URLs
-with text fragment directives. These recommendations aren’t normative but are
+with a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑦">text fragment directive</a>. These recommendations aren’t normative but are
 provided to ensure generated URLs result in maximally stable and usable URLs.</p>
    <h3 class="heading settled" data-level="3.1" id="prefer-exact-matching-to-range-based"><span class="secno">3.1. </span><span class="content">Prefer Exact Matching To Range-based</span><a class="self-link" href="#prefer-exact-matching-to-range-based"></a></h3>
    <p>The match text can be provided either as an exact string "text=foo%20bar%20baz"
@@ -2104,18 +2104,18 @@ encoded using an exact match. Above this limit, the UA should encode the string
 as a range-based match.</p>
    <div class="note" role="note"> TODO:  Can we determine the above limit in some more objective way? </div>
    <h3 class="heading settled" data-level="3.2" id="use-context-only-when-necessary"><span class="secno">3.2. </span><span class="content">Use Context Only When Necessary</span><a class="self-link" href="#use-context-only-when-necessary"></a></h3>
-   <p>Context terms allow the text fragment directive to disambiguate text snippets
+   <p>Context terms allow the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑧">text fragment directive</a> to disambiguate text snippets
 on a page. However, their use can make the URL more brittle in some cases.
 Often, the desired string will start or end at an element boundary. The context
 will therefore exist in an adjacent element. Changes to the page structure
-could invalidate the text fragment directive since the context and match text
+could invalidate the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑨">text fragment directive</a> since the context and match text
 may no longer appear to be adjacent.</p>
    <div class="example" id="example-735b40dc">
     <a class="self-link" href="#example-735b40dc"></a> Suppose we wish to craft a URL for the following text: 
 <pre>&lt;div class="section">HEADER&lt;/div>
 &lt;div class="content">Text to quote&lt;/div>
 </pre>
-    <p>We could craft the text fragment directive as follows:</p>
+    <p>We could craft the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive①⓪">text fragment directive</a> as follows:</p>
 <pre>text=HEADER-,Text%20to%20quote
 </pre>
     <p>However, suppose the page changes to add a "[edit]" link beside all section
@@ -2131,11 +2131,11 @@ true:</p>
    </ul>
    <div class="note" role="note"> TODO: Determine the numeric limit above in a more objective way </div>
    <h3 class="heading settled" data-level="3.3" id="determine-if-fragment-id-is-needed"><span class="secno">3.3. </span><span class="content">Determine If Fragment Id Is Needed</span><a class="self-link" href="#determine-if-fragment-id-is-needed"></a></h3>
-   <p>When the UA navigates to a URL containing a text fragment directive, it will
+   <p>When the UA navigates to a URL containing a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive①①">text fragment directive</a>, it will
 fallback to scrolling into view a regular element-id based fragment if it
 exists and the text fragment isn’t found.</p>
    <p>This can be useful to provide a fallback, in case the text in the document
-changes, invalidating the text fragment directive.</p>
+changes, invalidating the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive①②">text fragment directive</a>.</p>
    <div class="example" id="example-5990805b">
     <a class="self-link" href="#example-5990805b"></a> Suppose we wish to craft a URL to
   https://en.wikipedia.org/wiki/History_of_computing quoting the sentence: 
@@ -2325,16 +2325,18 @@ manipulations
      <li><a href="#fragmentdirective">definition of</a><span>, in §2.2.4</span>
     </ul>
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §2.2.1</span>
+   <li><a href="#fragment-directive-input">fragment directive input</a><span>, in §2.4.1</span>
+   <li><a href="#fragment-directive-string">fragment directive string</a><span>, in §2.4</span>
    <li><a href="#location">Location</a><span>, in §2.6</span>
    <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §2.2.4</span>
    <li><a href="#textdirective">TextDirective</a><span>, in §2.2.4</span>
    <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §2.2.4</span>
    <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §2.2.4</span>
    <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §2.2.4</span>
+   <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §2.2.4</span>
    <li><a href="#textmatchchar">TextMatchChar</a><span>, in §2.2.4</span>
    <li><a href="#textmatchstring">TextMatchString</a><span>, in §2.2.4</span>
    <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §2.2.4</span>
-   <li><a href="#valid-text-directive">valid text directive</a><span>, in §2.2.4</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -2360,9 +2362,12 @@ manipulations
   <aside class="dfn-panel" data-for="fragment-directive">
    <b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragment-directive">2.2.1. Parsing the fragment directive</a>
-    <li><a href="#ref-for-fragment-directive①">2.2.4. Fragment directive grammar</a>
-    <li><a href="#ref-for-fragment-directive">2.4. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-fragment-directive">2.1. Syntax</a>
+    <li><a href="#ref-for-fragment-directive①">2.2. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a>
+    <li><a href="#ref-for-fragment-directive③">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive④">(2)</a>
+    <li><a href="#ref-for-fragment-directive⑤">2.2.3. Processing the fragment directive</a> <a href="#ref-for-fragment-directive⑥">(2)</a>
+    <li><a href="#ref-for-fragment-directive⑦">2.2.4. Fragment directive grammar</a> <a href="#ref-for-fragment-directive⑧">(2)</a>
+    <li><a href="#ref-for-fragment-directive⑨">2.4. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragmentdirective">
@@ -2371,10 +2376,16 @@ manipulations
     <li><a href="#ref-for-fragmentdirective">2.2.4. Fragment directive grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-text-directive">
-   <b><a href="#valid-text-directive">#valid-text-directive</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="text-fragment-directive">
+   <b><a href="#text-fragment-directive">#text-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valid-text-directive">2.1. Syntax</a>
+    <li><a href="#ref-for-text-fragment-directive">2.1. Syntax</a>
+    <li><a href="#ref-for-text-fragment-directive①">2.3.1. Motivation</a> <a href="#ref-for-text-fragment-directive②">(2)</a> <a href="#ref-for-text-fragment-directive③">(3)</a> <a href="#ref-for-text-fragment-directive④">(4)</a>
+    <li><a href="#ref-for-text-fragment-directive⑤">2.3.2. Should Allow Text Fragment</a>
+    <li><a href="#ref-for-text-fragment-directive⑥">2.4. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-text-fragment-directive⑦">3. Generating Text Fragment Directives</a>
+    <li><a href="#ref-for-text-fragment-directive⑧">3.2. Use Context Only When Necessary</a> <a href="#ref-for-text-fragment-directive⑨">(2)</a> <a href="#ref-for-text-fragment-directive①⓪">(3)</a>
+    <li><a href="#ref-for-text-fragment-directive①①">3.3. Determine If Fragment Id Is Needed</a> <a href="#ref-for-text-fragment-directive①②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirective">
@@ -2417,6 +2428,18 @@ manipulations
    <b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentencodedchar">2.2.4. Fragment directive grammar</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fragment-directive-string">
+   <b><a href="#fragment-directive-string">#fragment-directive-string</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fragment-directive-string">2.4. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fragment-directive-input">
+   <b><a href="#fragment-directive-input">#fragment-directive-input</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fragment-directive-input">2.4.1. Find a target text</a> <a href="#ref-for-fragment-directive-input①">(2)</a> <a href="#ref-for-fragment-directive-input②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="current-locale">

--- a/index.html
+++ b/index.html
@@ -1659,15 +1659,15 @@ step 2:</p>
        <ul>
         <li data-md>
          <p>If <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> is U+003A (:) and <em>remaining</em> begins with the two
-consecutive code points U+007E (~) and U+003A (:), set state to <em>fragment-directive state</em>. Increment <a href="https://url.spec.whatwg.org/#pointer">URL Standard §pointer</a> by the
+consecutive code points U+007E (~) and U+003A (:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <a href="https://url.spec.whatwg.org/#pointer">URL Standard §pointer</a> by the
 length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive delimiter</a> minus 1.</p>
        </ul>
       <li data-md>
        <p>Step 3 (now step 4 after the above change) must begin with "Otherwise,"</p>
      </ul>
     <li data-md>
-     <p>In step 11 of this algorithm, add a new <em>fragment-directive state</em> case with the following steps:</p>
-     <p><em>fragment-directive state</em>:</p>
+     <p>In step 11 of this algorithm, add a new <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state①">fragment directive state</a> case with the following steps:</p>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-state">fragment directive state</dfn>:</p>
      <ul>
       <li data-md>
        <p>Switching on <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a>:</p>
@@ -2325,6 +2325,7 @@ manipulations
     </ul>
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §2.2.1</span>
    <li><a href="#fragment-directive-input">fragment directive input</a><span>, in §2.4.1</span>
+   <li><a href="#fragment-directive-state">fragment directive state</a><span>, in §2.2.1</span>
    <li><a href="#fragment-directive-string">fragment directive string</a><span>, in §2.4</span>
    <li><a href="#location">Location</a><span>, in §2.6</span>
    <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §2.2.4</span>
@@ -2368,6 +2369,12 @@ manipulations
     <li><a href="#ref-for-fragment-directive①③">2.2.3. Processing the fragment directive</a> <a href="#ref-for-fragment-directive①④">(2)</a> <a href="#ref-for-fragment-directive①⑤">(3)</a> <a href="#ref-for-fragment-directive①⑥">(4)</a> <a href="#ref-for-fragment-directive①⑦">(5)</a>
     <li><a href="#ref-for-fragment-directive①⑧">2.2.4. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①⑨">(2)</a>
     <li><a href="#ref-for-fragment-directive②⓪">2.4. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fragment-directive-state">
+   <b><a href="#fragment-directive-state">#fragment-directive-state</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fragment-directive-state">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive-state①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragmentdirective">

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 98212c11613b78977e54b28cc53499f2ee83d388" name="generator">
-  <link href="wicg.github.io/ScrollToTextFragment/draftspec.html" rel="canonical">
+  <link href="wicg.github.io/ScrollToTextFragment/index.html" rel="canonical">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1465,7 +1465,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="wicg.github.io/ScrollToTextFragment/draftspec.html">wicg.github.io/ScrollToTextFragment/draftspec.html</a>
+     <dd><a class="u-url" href="wicg.github.io/ScrollToTextFragment/index.html">wicg.github.io/ScrollToTextFragment/index.html</a>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/wicg/ScrollToTextFragment/issues/">GitHub</a>
      <dt class="editor">Editors:
@@ -1660,7 +1660,7 @@ step 2:</p>
        <ul>
         <li data-md>
          <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is U+003A (:) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> begins with the two consecutive code points U+007E (~) and U+003A
-(:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <a href="https://url.spec.whatwg.org/#pointer">pointer</a> by the length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive
+(:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <em>pointer</em> by the length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive
 delimiter</a> minus 1.</p>
        </ul>
       <li data-md>
@@ -1716,7 +1716,7 @@ to <em>output</em>.</p>
    <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:</p>
    <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Document’s fragment directive" data-noexport id="documents-fragment-directive">fragment
 directive</dfn>. </em></p>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> from the a Document’s URL.</p>
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> from the Document’s <a href="https://dom.spec.whatwg.org/#concept-document-url">URL</a>.</p>
    <p>Replace steps 7 and 8 of this algorithm with:</p>
    <ol start="7">
     <li data-md>
@@ -1776,12 +1776,12 @@ invoke. </div>
      <p>If any of the following conditions are true, return false.</p>
      <ul>
       <li data-md>
-       <p><em>window</em>’s parent field is non-null.</p>
+       <p><em>window</em>’s <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-parent">parent</a> field is non-null.</p>
       <li data-md>
-       <p><em>window</em>’s opener field is non-null.</p>
+       <p><em>window</em>’s <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-opener">opener</a> field is non-null.</p>
       <li data-md>
-       <p>The document of the previous entry in <em>window</em>’s browsing context’s
-session history is equal to <em>window</em>’s document.</p>
+       <p>The <a href="https://html.spec.whatwg.org/#document">Document</a> of the <a href="https://html.spec.whatwg.org/multipage/#latest-entry">latest entry</a> in <em>window</em>’s <a href="https://html.spec.whatwg.org/multipage/#browsing-context">browsing context</a>'s <a href="https://html.spec.whatwg.org/multipage/#session-history">session history</a> is equal to <em>window</em>’s
+document.</p>
        <div class="note" role="note"> That is, this is the result of a same document navigation </div>
       <li data-md>
        <p><em>is user triggered</em> is false.</p>
@@ -1797,7 +1797,7 @@ element fragment as the indicated part of the document. </div>
 indicated part of the document</a>.</p>
    <ol>
     <li data-md>
-     <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-string">fragment directive string</dfn> be the document <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive⑤">URL’s fragment
+     <p>Let <em>fragment directive string</em> be the document <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive⑤">URL’s fragment
 directive</a>.</p>
     <li data-md>
      <p>Let <em>is user activated</em> be true if the current navigation was <a href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
@@ -1809,27 +1809,27 @@ activation triggering </div>
 document’s browsing context and <em>is user activated</em> is true then:</p>
      <ol>
       <li data-md>
-       <p>If <a href="#find-a-target-text">§ 2.4.1 Find a target text</a> with <a data-link-type="dfn" href="#fragment-directive-string" id="ref-for-fragment-directive-string">fragment directive string</a> returns
+       <p>If <a href="#find-a-target-text">§ 2.4.1 Find a target text</a> with <em>fragment directive string</em> returns
 non-null, then the return value is the indicated part of the document;
 return.</p>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="2.4.1" id="find-a-target-text"><span class="secno">2.4.1. </span><span class="content">Find a target text</span><a class="self-link" href="#find-a-target-text"></a></h4>
-   <p>To find the target text for a given string <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-input">fragment directive input</dfn>,
+   <p>To find the target text for a given string <em>fragment directive input</em>,
 the user agent must run these steps:</p>
    <ol>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#fragment-directive-input" id="ref-for-fragment-directive-input">fragment directive input</a> does not begin with the string "text=",
+     <p>If <em>fragment directive input</em> does not begin with the string "text=",
 then return null.</p>
     <li data-md>
-     <p>Let <em>raw target text</em> be the substring of <a data-link-type="dfn" href="#fragment-directive-input" id="ref-for-fragment-directive-input①">fragment directive input</a> starting at index 5.</p>
-     <div class="note" role="note"> This is the remainder of the <a data-link-type="dfn" href="#fragment-directive-input" id="ref-for-fragment-directive-input②">fragment directive input</a> following, but not
+     <p>Let <em>raw target text</em> be the substring of <em>fragment directive input</em> starting at index 5.</p>
+     <div class="note" role="note"> This is the remainder of the <em>fragment directive input</em> following, but not
 including, the "text=" prefix. </div>
     <li data-md>
      <p>If <em>raw target text</em> is the empty string, return null.</p>
     <li data-md>
-     <p>Let <em>tokens</em> be a list of strings that is the result of splitting the
-string <em>raw target text</em> on commas.</p>
+     <p>Let <em>tokens</em> be a <a href="https://infra.spec.whatwg.org/#list">list</a> of strings that is the result of <a href="https://infra.spec.whatwg.org/#split-on-commas">splitting a string on commas</a> of <em>raw target
+text</em>.</p>
     <li data-md>
      <p>Let <em>prefix</em> and <em>suffix</em> and <em>textEnd</em> be the empty
 string.</p>
@@ -1843,7 +1843,7 @@ directive. </div>
       <li data-md>
        <p>Set <em>prefix</em> to the result of removing the last character from <em>potential prefix</em>.</p>
       <li data-md>
-       <p>Remove the first item of the list <em>tokens</em>.</p>
+       <p><a href="https://infra.spec.whatwg.org/#list-remove">Remove</a> the first item of the list <em>tokens</em>.</p>
      </ol>
     <li data-md>
      <p>Let <em>potential suffix</em> be the last item of <em>tokens</em>.</p>
@@ -1853,23 +1853,23 @@ directive. </div>
       <li data-md>
        <p>Set <em>suffix</em> to the result of removing the first character from <em>potential suffix</em>.</p>
       <li data-md>
-       <p>Remove the last item of the list <em>tokens</em>.</p>
+       <p><a href="https://infra.spec.whatwg.org/#list-remove">Remove</a> the last item of the list <em>tokens</em>.</p>
      </ol>
     <li data-md>
-     <p class="assertion">Assert: <em>tokens</em> has size 1 or <em>tokens</em> has size 2.</p>
+     <p class="assertion">Assert: <em>tokens</em> has <a href="https://infra.spec.whatwg.org/#list-size">size</a> 1 or <em>tokens</em> has <a href="https://infra.spec.whatwg.org/#list-size">size</a> 2.</p>
      <div class="note" role="note"> Once the prefix and suffix are removed from tokens, tokens may either
 contain one item (textStart) or two items (textStart and textEnd). </div>
     <li data-md>
      <p>Let <em>textStart</em> be the first item of <em>tokens</em>.</p>
     <li data-md>
-     <p>If <em>tokens</em> has size 2, then let <em>textEnd</em> be the last item of <em>tokens</em>.</p>
+     <p>If <em>tokens</em> has <a href="https://infra.spec.whatwg.org/#list-size">size</a> 2, then let <em>textEnd</em> be the last item of <em>tokens</em>.</p>
      <div class="note" role="note"> The strings prefix, textStart, textEnd, and suffix now contain the
 text directive parameters as defined in <a href="#syntax">§ 2.1 Syntax</a>. </div>
     <li data-md>
      <p>Let <em>walker</em> be a <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> equal to <a href="https://dom.spec.whatwg.org/#dom-document-createtreewalker">Document.createTreeWalker()</a>.</p>
     <li data-md>
-     <p>Let <em>position</em> be a position variable that indicates a text offset in
-in <em>walker.currentNode.innerText</em>.</p>
+     <p>Let <em>position</em> be a <a href="https://infra.spec.whatwg.org/#string-position-variable">position
+variable</a> that indicates a text offset in <em>walker.currentNode.innerText</em>.</p>
     <li data-md>
      <p>If textEnd is the empty string, then:</p>
      <ol>
@@ -1906,8 +1906,8 @@ position - start position</em>.</p>
    </ol>
    <h4 class="heading settled" data-level="2.4.2" id="find-match-with-context"><span class="secno">2.4.2. </span><span class="content">Find an exact match with context</span><a class="self-link" href="#find-match-with-context"></a></h4>
    <div class="note" role="note"> This algorithm has input <em>walker, search position, prefix, query,</em> and <em>suffix</em> and returns a text position that is the start of the match. </div>
-   <div class="note" role="note"> The input <em>walker</em> is a <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> reference, not
-a copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
+   <div class="note" role="note"> The input <em>walker</em> is a <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> reference, not a
+copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
    <ol>
     <li data-md>
      <p>While <em>walker.currentNode</em> is not null:</p>
@@ -1929,7 +1929,7 @@ locale</a>.</p>
           <li data-md>
            <p>If <em>search position</em> is null, then break.</p>
           <li data-md>
-           <p>Advance <em>search position</em> past any whitespace.</p>
+           <p><a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">Skip ASCII whitespace</a> on <em>search position</em>.</p>
           <li data-md>
            <p>If <em>search position</em> is at the end of <em>text</em>, then:</p>
            <ol>
@@ -1942,7 +1942,7 @@ locale</a>.</p>
             <li data-md>
              <p>Set <em>search position</em> to the beginning of <em>text</em>.</p>
             <li data-md>
-             <p>Advance <em>search position</em> past any whitespace.</p>
+             <p><a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">Skip ASCII whitespace</a> on <em>search position</em>.</p>
            </ol>
           <li data-md>
            <p>If the result of <a href="#next-word-bounded-instance">§ 2.4.4 Find the next word bounded instance</a> of <em>query</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale①">current locale</a> does not start at <em>search
@@ -1957,12 +1957,12 @@ instance of query. </div>
         <li data-md>
          <p>If <em>search position</em> is null, then break.</p>
         <li data-md>
-         <p>Let <em>potential match position</em> be a position variable equal to <em>search position</em> minus the length of <em>query</em>.</p>
+         <p>Let <em>potential match position</em> be a <a href="https://infra.spec.whatwg.org/#string-position-variable">position variable</a> equal to <em>search position</em> minus the length of <em>query</em>.</p>
         <li data-md>
          <p>If <em>suffix</em> is the empty string, then return <em>potential
 match position</em>.</p>
         <li data-md>
-         <p>Advance <em>search position</em> past any whitespace.</p>
+         <p><a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">Skip ASCII whitespace</a> on <em>search position</em>.</p>
         <li data-md>
          <p>If <em>search position</em> is at the end of <em>text</em>, then:</p>
          <ol>
@@ -1977,7 +1977,7 @@ match position</em>.</p>
           <li data-md>
            <p>Set <em>search position</em> to the beginning of <em>text</em>.</p>
           <li data-md>
-           <p>Advance <em>search position</em> past any whitespace.</p>
+           <p><a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">Skip ASCII whitespace</a> on <em>search position</em>.</p>
          </ol>
         <li data-md>
          <p>If the result of <a href="#next-word-bounded-instance">§ 2.4.4 Find the next word bounded instance</a> of <em>suffix</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale③">current
@@ -1991,8 +1991,8 @@ locale</a> starts at <em>search position</em>, then return <em>potential match p
    </ol>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="current-locale">current locale</dfn> is the <a href="https://html.spec.whatwg.org/multipage/dom.html#language">language</a> of the <em>currentNode</em>.</p>
    <h4 class="heading settled" data-level="2.4.3" id="advance-walker-to-text"><span class="secno">2.4.3. </span><span class="content">Advance a TreeWalker to the next text node</span><a class="self-link" href="#advance-walker-to-text"></a></h4>
-   <div class="note" role="note"> The input <em>walker</em> is a <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> reference, not
-a copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
+   <div class="note" role="note"> The input <em>walker</em> is a <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> reference, not a
+copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
    <ol>
     <li data-md>
      <p>While the input <em>walker.currentNode</em> is not null and <em>walker.currentNode</em> is not a text node:</p>
@@ -2056,8 +2056,8 @@ exfiltration.</p>
    <p>The UA must not visually indicate any provided context terms.</p>
    <h3 class="heading settled" data-level="2.6" id="feature-detectability"><span class="secno">2.6. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
-that is exposed via window.location.fragmentDirective if the UA supports the
-feature.</p>
+that is exposed via <code>window.location.fragmentDirective</code> if the UA
+supports the feature.</p>
 <pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="fragmentdirective①"><code><c- g>FragmentDirective</c-></code></dfn> {
 };
 </pre>
@@ -2326,9 +2326,7 @@ manipulations
      <li><a href="#fragmentdirective">definition of</a><span>, in §2.2.4</span>
     </ul>
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §2.2.1</span>
-   <li><a href="#fragment-directive-input">fragment directive input</a><span>, in §2.4.1</span>
    <li><a href="#fragment-directive-state">fragment directive state</a><span>, in §2.2.1</span>
-   <li><a href="#fragment-directive-string">fragment directive string</a><span>, in §2.4</span>
    <li><a href="#location">Location</a><span>, in §2.6</span>
    <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §2.2.4</span>
    <li><a href="#textdirective">TextDirective</a><span>, in §2.2.4</span>
@@ -2451,18 +2449,6 @@ manipulations
    <b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentencodedchar">2.2.4. Fragment directive grammar</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="fragment-directive-string">
-   <b><a href="#fragment-directive-string">#fragment-directive-string</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-fragment-directive-string">2.4. Navigating to a Text Fragment</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="fragment-directive-input">
-   <b><a href="#fragment-directive-input">#fragment-directive-input</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-fragment-directive-input">2.4.1. Find a target text</a> <a href="#ref-for-fragment-directive-input①">(2)</a> <a href="#ref-for-fragment-directive-input②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="current-locale">

--- a/index.html
+++ b/index.html
@@ -1631,24 +1631,24 @@ introduces the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fr
 of the URL fragment delimited by the code sequence <code>:~:</code>. It is
 reserved for UA instructions, such as text=, and is stripped from the URL
 during loading so that author scripts can’t directly interact with it. 
-   <p>The fragment-directive is a mechanism for URLs to specify instructions meant
+   <p>The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive③">fragment directive</a> is a mechanism for URLs to specify instructions meant
 for the UA rather than the document. It’s meant to avoid direct interaction with
 author script so that future UA instructions can be added without fear of
 introducing breaking changes to existing content. Potential examples could be:
 translation-hints or enabling accessibility features.</p>
    <h4 class="heading settled" data-level="2.2.1" id="parsing-the-fragment-directive"><span class="secno">2.2.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
    <p>To the definition of a <a href="https://url.spec.whatwg.org/#concept-url"> URL record</a>, add:</p>
-   <p><em> A URL’s fragment-directive is either null or an ASCII string holding data used
+   <p><em> A URL’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> is either null or an ASCII string holding data used
 by the UA to process the resource. It is initially null </em></p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-delimiter">fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> is the part of the URL fragment that follows
 the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive delimiter</a>.</p>
-   <div class="note" role="note"> The fragment-directive is part of the URL fragment. This means it must always
+   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a> is part of the URL fragment. This means it must always
   appear after a U+0023 (#) code point in a URL. </div>
-   <div class="example" id="example-8a44ecf3"><a class="self-link" href="#example-8a44ecf3"></a> To add a fragment-directive to a URL like https://example.com, a fragment
+   <div class="example" id="example-aa58e32d"><a class="self-link" href="#example-aa58e32d"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> to a URL like https://example.com, a fragment
   must first be appended to the URL: https://example.com#:~:text=foo. </div>
-   <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive③">fragment directive</a> in a URL:</p>
+   <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> in a URL:</p>
    <ul>
     <li data-md>
      <p>In step 11 of this algorithm, amend the <em>fragment state</em> case:</p>
@@ -1693,10 +1693,10 @@ and append the result to <em>url’s fragment-directive</em>.</p>
      </ul>
    </ul>
    <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive delimiter</a>.
-  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> includes all characters that follow, but not including,
+  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> includes all characters that follow, but not including,
   the delimiter. </div>
-   <div class="example" id="example-cac370ee"><a class="self-link" href="#example-cac370ee"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
-the fragment is the string "test" and the fragment-directive is the string
+   <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
+the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> is the string
 "text=foo". </div>
    <h4 class="heading settled" data-level="2.2.2" id="serializing-the-fragment-directive"><span class="secno">2.2.2. </span><span class="content">Serializing the fragment directive</span><a class="self-link" href="#serializing-the-fragment-directive"></a></h4>
    <p>Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer </a> steps by inserting a step after step 7:</p>
@@ -1713,8 +1713,8 @@ non-null:</p>
    </ol>
    <h4 class="heading settled" data-level="2.2.3" id="processing-the-fragment-directive"><span class="secno">2.2.3. </span><span class="content">Processing the fragment directive</span><a class="self-link" href="#processing-the-fragment-directive"></a></h4>
    <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:</p>
-   <p><em> Each document has an associated <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a>. </em></p>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> from the a Document’s URL.</p>
+   <p><em> Each document has an associated <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a>. </em></p>
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> from the a Document’s URL.</p>
    <p>Replace steps 7 and 8 of this algorithm with:</p>
    <ol start="7">
     <li data-md>
@@ -1735,13 +1735,13 @@ web-exposed)</p>
    </ol>
    <h4 class="heading settled" data-level="2.2.4" id="fragment-directive-grammar"><span class="secno">2.2.4. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
     A <dfn data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive<a class="self-link" href="#valid-fragment-directive"></a></dfn> is a sequence of characters that appears
-in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> that matches the production: 
+in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a> that matches the production: 
    <dl> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirective">FragmentDirective</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> ("&amp;" <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a>)*</dd></code> </dl>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective">FragmentDirective</a> may contain multiple directives split by the "&amp;"
 character. Currently this means we allow multiple text directives to enable
 multiple indicated strings in the page, but this also allows for future
 directive types to be added and combined. </div>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> that
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> that
 enables specifying a piece of text on the page, that matches the production:</p>
    <dl>
      <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt> <dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters">TextDirectiveParameters</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring">TextMatchString</a> ("," <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring①">TextMatchString</a>)? ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix">TextDirectivePrefix</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring②">TextMatchString</a> "-"</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix">TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring③">TextMatchString</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchstring">TextMatchString</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar">TextMatchChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchchar">TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code> 
@@ -1797,7 +1797,7 @@ element fragment as the indicated part of the document. </div>
 indicated part of the document</a>.</p>
    <ol>
     <li data-md>
-     <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-string">fragment directive string</dfn> be the document URL’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment
+     <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-string">fragment directive string</dfn> be the document URL’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment
 directive</a>.</p>
     <li data-md>
      <p>Let <em>is user activated</em> be true if the current navigation was <a href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
@@ -2363,11 +2363,11 @@ manipulations
    <b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-directive">2.1. Syntax</a>
-    <li><a href="#ref-for-fragment-directive①">2.2. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a>
-    <li><a href="#ref-for-fragment-directive③">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive④">(2)</a>
-    <li><a href="#ref-for-fragment-directive⑤">2.2.3. Processing the fragment directive</a> <a href="#ref-for-fragment-directive⑥">(2)</a>
-    <li><a href="#ref-for-fragment-directive⑦">2.2.4. Fragment directive grammar</a> <a href="#ref-for-fragment-directive⑧">(2)</a>
-    <li><a href="#ref-for-fragment-directive⑨">2.4. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-fragment-directive①">2.2. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a>
+    <li><a href="#ref-for-fragment-directive④">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a> <a href="#ref-for-fragment-directive⑨">(6)</a>
+    <li><a href="#ref-for-fragment-directive①⓪">2.2.3. Processing the fragment directive</a> <a href="#ref-for-fragment-directive①①">(2)</a>
+    <li><a href="#ref-for-fragment-directive①②">2.2.4. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①③">(2)</a>
+    <li><a href="#ref-for-fragment-directive①④">2.4. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragmentdirective">

--- a/index.html
+++ b/index.html
@@ -1687,34 +1687,34 @@ error.</p>
 two ASCII hex digits, validation error.</p>
           <li data-md>
            <p>UTF-8 percent encode <a href="https://url.spec.whatwg.org/#c">URL Standard §c</a> using the fragment percent-encode set
-and append the result to <em>url’s fragment-directive</em>.</p>
+and append the result to <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a>.</p>
          </ol>
        </ul>
      </ul>
    </ul>
    <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive delimiter</a>.
-  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> includes all characters that follow, but not including,
+  The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> includes all characters that follow, but not including,
   the delimiter. </div>
    <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
-the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> is the string
+the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a> is the string
 "text=foo". </div>
    <h4 class="heading settled" data-level="2.2.2" id="serializing-the-fragment-directive"><span class="secno">2.2.2. </span><span class="content">Serializing the fragment directive</span><a class="self-link" href="#serializing-the-fragment-directive"></a></h4>
    <p>Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer </a> steps by inserting a step after step 7:</p>
    <ol start="8">
     <li data-md>
-     <p>If the <em>exclude fragment flag</em> is unset and <em>url’s fragment-directive</em> is
+     <p>If the <em>exclude fragment flag</em> is unset and <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> is
 non-null:</p>
      <ol>
       <li data-md>
        <p>If <em>url’s fragment</em> is null, append U+0023 (#) to <em>output</em>.</p>
       <li data-md>
-       <p>Append ":~:", followed by <em>url’s fragment-directive</em>, to <em>output</em>.</p>
+       <p>Append ":~:", followed by <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a>, to <em>output</em>.</p>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="2.2.3" id="processing-the-fragment-directive"><span class="secno">2.2.3. </span><span class="content">Processing the fragment directive</span><a class="self-link" href="#processing-the-fragment-directive"></a></h4>
    <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:</p>
-   <p><em> Each document has an associated <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a>. </em></p>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> from the a Document’s URL.</p>
+   <p><em> Each document has an associated <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a>. </em></p>
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment directive</a> from the a Document’s URL.</p>
    <p>Replace steps 7 and 8 of this algorithm with:</p>
    <ol start="7">
     <li data-md>
@@ -1725,23 +1725,22 @@ current URL</em>.</p>
     <li data-md>
      <p>Otherwise, set <em>url</em> to <em>response’s URL</em>.</p>
     <li data-md>
-     <p>Set <em>document’s fragment-directive</em> be <em>url’s
-fragment-directive</em>.  (Note: this is stored on the document but not
+     <p>Set <em>document’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑤">fragment directive</a> be <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑥">fragment directive</a>.  (Note: this is stored on the document but not
 web-exposed)</p>
     <li data-md>
-     <p>Set <em>url’s fragment-directive</em> to null.</p>
+     <p>Set <em>url’s</em> <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑦">fragment directive</a> to null.</p>
     <li data-md>
      <p>Set the <em>document’s url</em> to be <em>url</em>.</p>
    </ol>
    <h4 class="heading settled" data-level="2.2.4" id="fragment-directive-grammar"><span class="secno">2.2.4. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
     A <dfn data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive<a class="self-link" href="#valid-fragment-directive"></a></dfn> is a sequence of characters that appears
-in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a> that matches the production: 
+in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑧">fragment directive</a> that matches the production: 
    <dl> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirective">FragmentDirective</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> ("&amp;" <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a>)*</dd></code> </dl>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective">FragmentDirective</a> may contain multiple directives split by the "&amp;"
 character. Currently this means we allow multiple text directives to enable
 multiple indicated strings in the page, but this also allows for future
 directive types to be added and combined. </div>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> that
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑨">fragment directive</a> that
 enables specifying a piece of text on the page, that matches the production:</p>
    <dl>
      <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt> <dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters">TextDirectiveParameters</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring">TextMatchString</a> ("," <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring①">TextMatchString</a>)? ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix">TextDirectivePrefix</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring②">TextMatchString</a> "-"</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix">TextDirectiveSuffix</dfn> ::=</dt> <dd>"-" <a data-link-type="dfn" href="#textmatchstring" id="ref-for-textmatchstring③">TextMatchString</a></dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchstring">TextMatchString</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textmatchchar" id="ref-for-textmatchchar">TextMatchChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textmatchchar">TextMatchChar</dfn> ::=</dt> <dd>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</dd></code> 
@@ -1797,7 +1796,7 @@ element fragment as the indicated part of the document. </div>
 indicated part of the document</a>.</p>
    <ol>
     <li data-md>
-     <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-string">fragment directive string</dfn> be the document URL’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment
+     <p>Let <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-string">fragment directive string</dfn> be the document URL’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive②⓪">fragment
 directive</a>.</p>
     <li data-md>
      <p>Let <em>is user activated</em> be true if the current navigation was <a href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
@@ -2364,10 +2363,11 @@ manipulations
    <ul>
     <li><a href="#ref-for-fragment-directive">2.1. Syntax</a>
     <li><a href="#ref-for-fragment-directive①">2.2. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a>
-    <li><a href="#ref-for-fragment-directive④">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a> <a href="#ref-for-fragment-directive⑨">(6)</a>
-    <li><a href="#ref-for-fragment-directive①⓪">2.2.3. Processing the fragment directive</a> <a href="#ref-for-fragment-directive①①">(2)</a>
-    <li><a href="#ref-for-fragment-directive①②">2.2.4. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①③">(2)</a>
-    <li><a href="#ref-for-fragment-directive①④">2.4. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-fragment-directive④">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a> <a href="#ref-for-fragment-directive⑨">(6)</a> <a href="#ref-for-fragment-directive①⓪">(7)</a>
+    <li><a href="#ref-for-fragment-directive①①">2.2.2. Serializing the fragment directive</a> <a href="#ref-for-fragment-directive①②">(2)</a>
+    <li><a href="#ref-for-fragment-directive①③">2.2.3. Processing the fragment directive</a> <a href="#ref-for-fragment-directive①④">(2)</a> <a href="#ref-for-fragment-directive①⑤">(3)</a> <a href="#ref-for-fragment-directive①⑥">(4)</a> <a href="#ref-for-fragment-directive①⑦">(5)</a>
+    <li><a href="#ref-for-fragment-directive①⑧">2.2.4. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①⑨">(2)</a>
+    <li><a href="#ref-for-fragment-directive②⓪">2.4. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragmentdirective">

--- a/index.html
+++ b/index.html
@@ -1711,7 +1711,8 @@ the fragment is the string "test" and the <a data-link-type="dfn" href="#fragmen
 non-null:</p>
      <ol>
       <li data-md>
-       <p>If <em>url’s fragment</em> is null, append U+0023 (#) to <em>output</em>.</p>
+       <p>If <a href="https://url.spec.whatwg.org/#concept-url-fragment">url’s fragment</a> is null, append U+0023 (#)
+to <em>output</em>.</p>
       <li data-md>
        <p>Append ":~:", followed by <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive②">URL’s fragment directive</a>, to <em>output</em>.</p>
      </ol>
@@ -1726,17 +1727,16 @@ directive</dfn>. </em></p>
     <li data-md>
      <p>Let <em>url</em> be null</p>
     <li data-md>
-     <p>If <em>request</em> is non-null, then set <em>url</em> to <em>request’s
-current URL</em>.</p>
+     <p>If <em>request</em> is non-null, then set <em>document</em>’s <a href="https://dom.spec.whatwg.org/#concept-document-url">URL</a> to <em>request</em>’s <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">current URL</a>.</p>
     <li data-md>
-     <p>Otherwise, set <em>url</em> to <em>response’s URL</em>.</p>
+     <p>Otherwise, set <em>url</em> to <em>response</em>’s <a href="https://fetch.spec.whatwg.org/#concept-response-url">URL</a>.</p>
     <li data-md>
      <p>Set <a data-link-type="dfn" href="#documents-fragment-directive" id="ref-for-documents-fragment-directive">Document’s fragment directive</a> to <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive③">URL’s fragment directive</a>.
 (Note: this is stored on the document but not web-exposed)</p>
     <li data-md>
      <p>Set <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive④">URL’s fragment directive</a> to null.</p>
     <li data-md>
-     <p>Set the <em>document’s url</em> to be <em>url</em>.</p>
+     <p>Set <em>document</em>’s <a href="https://dom.spec.whatwg.org/#concept-document-url">URL</a> to be <em>url</em>.</p>
    </ol>
    <h4 class="heading settled" data-level="2.2.4" id="fragment-directive-grammar"><span class="secno">2.2.4. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
     A <dfn data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive<a class="self-link" href="#valid-fragment-directive"></a></dfn> is a sequence of characters that appears


### PR DESCRIPTION
Adds definitions for some terms, and various cross-spec references to DOM, HTML, URL, and spec Infra concepts. I added URL spec references for consistency, but they will end up being removed with #60.

Also fixed some existing bikeshed formatting errors and warnings.

Fixes #36.