### PR TITLE
Move fragment directive parsing to Document initialization

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -120,7 +120,7 @@ translation-hints or enabling accessibility features.
 ### Parsing the fragment directive ### {#parsing-the-fragment-directive}
 
 To the definition of
-<a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:
+<a href="https://dom.spec.whatwg.org/#concept-document">Document</a>, add:
 
 <em>
 Each document has an associated <dfn>fragment directive</dfn> which is either

--- a/index.bs
+++ b/index.bs
@@ -119,20 +119,17 @@ translation-hints or enabling accessibility features.
 
 ### Parsing the fragment directive ### {#parsing-the-fragment-directive}
 
-To the definition of a <a href="https://url.spec.whatwg.org/#concept-url">
-URL record</a>, add:
+To the definition of
+<a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:
 
 <em>
-A [[URL#concept-url|URL]]'s <dfn lt="URL's fragment directive">fragment
-directive</dfn> is either null or an ASCII string holding data used by the UA to
-process the resource. It is initially null.
+Each document has an associated <dfn>fragment directive</dfn> which is either
+null or an ASCII string holding data used by the UA to process the resource. It
+is initially null.
 </em>
 
 The <dfn>fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).
-
-The <dfn>fragment directive</dfn> is the part of the URL fragment that follows
-the [=fragment directive delimiter=].
 
 <div class="note">
   The [=fragment directive=] is part of the URL fragment. This means it must
@@ -144,36 +141,42 @@ the [=fragment directive delimiter=].
   must first be appended to the URL: https://example.com#:~:text=foo.
 </div>
 
-Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser">
-basic URL parser</a> steps to parse the [=fragment directive=] in a URL:
+Amend the
+<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">
+create and initialize a Document object</a> steps to parse and remove the
+[=fragment directive=] from the Document's [[DOM#concept-document-url|URL]].
 
-  - In step 11 of this algorithm, amend the [[URL#fragment-state|fragment
-    state]] case:
-    - In the inner switch on [[URL#c|c]], in the Otherwise case, add a step
-        after step 2:
-        - If [[URL#c|c]] is U+003A (:) and
-            <a href="https://url.spec.whatwg.org/#remaining">remaining</a>
-            begins with the two consecutive code points U+007E (~) and U+003A
-            (:), set state to [=fragment directive state=]. Increment 
-            <em>pointer</em> by the length of the [=fragment directive
-            delimiter=] minus 1.
-    - Step 3 (now step 4 after the above change) must begin with "Otherwise,"
-  - In step 11 of this algorithm, add a new [=fragment directive state=]
-    case with the following steps:
-    
-    <dfn>fragment directive state</dfn>:
-    - Switching on [[URL#c|c]]:
-        - The EOF code point: Do nothing
-        - U+0000 NULL: Validation error
-        - Otherwise:
-            1. If [[URL#c|c]] is not a URL code point and not U+0025 (%),
-                validation error.
-            2. If [[URL#c|c]] is U+0025 (%) and
-                <a href="https://url.spec.whatwg.org/#remaining">remaining</a>
-                does not start with two ASCII hex digits, validation error.
-            3. UTF-8 percent encode [[URL#c|c]] using the fragment
-                percent-encode set and append the result to [=URL's fragment
-                directive=].
+Replace steps 7 and 8 of this algorithm with:
+
+7. Let <em>url</em> be null
+8. If <em>request</em> is non-null, then set <em>document</em>'s
+    [[DOM#concept-document-url|URL]] to <em>request</em>'s
+    [[FETCH#concept-request-current-url|current URL]].
+9. Otherwise, set <em>url</em> to <em>response</em>'s
+    [[FETCH#concept-response-url|URL]].
+10. Let <em>raw fragment</em> be equal to <em>url</em>'s
+    [[URL#concept-url-fragment|fragment]].
+11. Let <em>fragment directive position</em> be a
+    [[INFRA#string-position-variable|position variable]] that points to the
+    beginning of <em>raw fragment</em>.
+12. While the string starting at position <em>fragment directive position</em>
+    does not start with the [=fragment directive delimiter=] and <em>fragment
+    directive position</em> does not point past the end of <em>raw fragment</em>:
+    1. Advance <em>fragment directive position</em> by 1.
+13. If <em>fragment directive position</em> does not point past the end of
+    <em>raw fragment</em>:
+    1. Let <em>fragment</em> be the substring of <em>raw fragment</em> ending at
+        <em>fragment directive position</em>.
+    2. Advance <em>fragment directive position</em> by the length of [=fragment
+        directive delimiter=].
+    3. Let <em>fragment directive</em> be the substring of <em>raw fragment</em>
+        starting at <em>fragment directive position</em>.
+    4. Set <em>url</em>'s [[URL#concept-url-fragment|fragment]] to
+        <em>fragment</em>.
+    5. Set <em>document</em>'s [=fragment directive=] to <em>fragment
+        directive</em>. (Note: this is stored on the document but not
+        web-exposed)
+14. Set <em>document</em>'s [[DOM#concept-document-url|URL]] to be <em>url</em>.
 
 <div class="note">
   These changes make a URL's fragment end at the [=fragment directive
@@ -192,40 +195,13 @@ the fragment is the string "test" and the [=fragment directive=] is the string
 Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer
 </a> steps by inserting a step after step 7:
 
-8. If the <em>exclude fragment flag</em> is unset and [=URL's fragment
+8. If the <em>exclude fragment flag</em> is unset and <em>url</em> has an
+    associated Document <em>document</em> and <em>document</em>'s [=fragment
     directive=] is non-null:
-    1. If [[URL#concept-url-fragment|url's fragment]] is null, append U+0023 (#)
-        to <em>output</em>.
-    2. Append ":~:", followed by [=URL's fragment directive=], to
+    1. If <em>url</em>'s [[URL#concept-url-fragment|fragment]] is null, append
+        U+0023 (#) to <em>output</em>.
+    2. Append ":~:", followed by <em>document</em>'s [=fragment directive=], to
         <em>output</em>.
-
-### Processing the fragment directive ### {#processing-the-fragment-directive}
-
-To the definition of
-<a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:
-
-<em>
-Each document has an associated <dfn lt="Document's fragment directive">fragment
-directive</dfn>.
-</em>
-
-Amend the
-<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">
-create and initialize a Document object</a> steps to store and remove the
-[=fragment directive=] from the Document's [[DOM#concept-document-url|URL]].
-
-Replace steps 7 and 8 of this algorithm with:
-
-7. Let <em>url</em> be null
-8. If <em>request</em> is non-null, then set <em>document</em>'s
-    [[DOM#concept-document-url|URL]] to <em>request</em>'s
-    [[FETCH#concept-request-current-url|current URL]].
-9. Otherwise, set <em>url</em> to <em>response</em>'s
-    [[FETCH#concept-response-url|URL]].
-10. Set [=Document's fragment directive=] to [=URL's fragment directive=].
-    (Note: this is stored on the document but not web-exposed)
-11. Set [=URL's fragment directive=] to null.
-12. Set <em>document</em>'s [[DOM#concept-document-url|URL]] to be <em>url</em>.
 
 ### Fragment directive grammar ### {#fragment-directive-grammar}
 A <dfn>valid fragment directive</dfn> is a sequence of characters that appears
@@ -363,7 +339,7 @@ Add the following steps to the beginning of the processing model for <a
 href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">
 The indicated part of the document</a>.
 
-1. Let <em>fragment directive string</em> be the document [=URL's fragment
+1. Let <em>fragment directive string</em> be the <em>document</em>'s [=fragment
     directive=].
 2. Let <em>is user activated</em> be true if the current navigation was <a
     href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered

--- a/index.html
+++ b/index.html
@@ -1637,7 +1637,7 @@ author script so that future UA instructions can be added without fear of
 introducing breaking changes to existing content. Potential examples could be:
 translation-hints or enabling accessibility features.</p>
    <h4 class="heading settled" data-level="2.2.1" id="parsing-the-fragment-directive"><span class="secno">2.2.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
-   <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:</p>
+   <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document">Document</a>, add:</p>
    <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is either
 null or an ASCII string holding data used by the UA to process the resource. It
 is initially null. </em></p>

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 98212c11613b78977e54b28cc53499f2ee83d388" name="generator">
+  <meta content="Bikeshed version 0e7769cca82774609b9dc8700c9a84ef436a1a12" name="generator">
   <link href="wicg.github.io/ScrollToTextFragment/index.html" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1523,8 +1523,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <ol class="toc">
         <li><a href="#parsing-the-fragment-directive"><span class="secno">2.2.1</span> <span class="content">Parsing the fragment directive</span></a>
         <li><a href="#serializing-the-fragment-directive"><span class="secno">2.2.2</span> <span class="content">Serializing the fragment directive</span></a>
-        <li><a href="#processing-the-fragment-directive"><span class="secno">2.2.3</span> <span class="content">Processing the fragment directive</span></a>
-        <li><a href="#fragment-directive-grammar"><span class="secno">2.2.4</span> <span class="content">Fragment directive grammar</span></a>
+        <li><a href="#fragment-directive-grammar"><span class="secno">2.2.3</span> <span class="content">Fragment directive grammar</span></a>
        </ol>
       <li>
        <a href="#allow-text-fragment-directives"><span class="secno">2.3</span> <span class="content">Security and Privacy</span></a>
@@ -1638,88 +1637,17 @@ author script so that future UA instructions can be added without fear of
 introducing breaking changes to existing content. Potential examples could be:
 translation-hints or enabling accessibility features.</p>
    <h4 class="heading settled" data-level="2.2.1" id="parsing-the-fragment-directive"><span class="secno">2.2.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
-   <p>To the definition of a <a href="https://url.spec.whatwg.org/#concept-url"> URL record</a>, add:</p>
-   <p><em> A <a href="https://url.spec.whatwg.org/#concept-url">URL</a>'s <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="URL’s fragment directive" data-noexport id="urls-fragment-directive">fragment
-directive</dfn> is either null or an ASCII string holding data used by the UA to
-process the resource. It is initially null. </em></p>
+   <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:</p>
+   <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is either
+null or an ASCII string holding data used by the UA to process the resource. It
+is initially null. </em></p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-delimiter">fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> is the part of the URL fragment that follows
-the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive delimiter</a>.</p>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> is part of the URL fragment. This means it must
   always appear after a U+0023 (#) code point in a URL. </div>
    <div class="example" id="example-aa58e32d"><a class="self-link" href="#example-aa58e32d"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a> to a URL like https://example.com, a fragment
   must first be appended to the URL: https://example.com#:~:text=foo. </div>
-   <p>Amend the <a href="https://url.spec.whatwg.org/#concept-basic-url-parser"> basic URL parser</a> steps to parse the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> in a URL:</p>
-   <ul>
-    <li data-md>
-     <p>In step 11 of this algorithm, amend the <a href="https://url.spec.whatwg.org/#fragment-state">fragment
-state</a> case:</p>
-     <ul>
-      <li data-md>
-       <p>In the inner switch on <a href="https://url.spec.whatwg.org/#c">c</a>, in the Otherwise case, add a step
-after step 2:</p>
-       <ul>
-        <li data-md>
-         <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is U+003A (:) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> begins with the two consecutive code points U+007E (~) and U+003A
-(:), set state to <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state">fragment directive state</a>. Increment <em>pointer</em> by the length of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive
-delimiter</a> minus 1.</p>
-       </ul>
-      <li data-md>
-       <p>Step 3 (now step 4 after the above change) must begin with "Otherwise,"</p>
-     </ul>
-    <li data-md>
-     <p>In step 11 of this algorithm, add a new <a data-link-type="dfn" href="#fragment-directive-state" id="ref-for-fragment-directive-state①">fragment directive state</a> case with the following steps:</p>
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-state">fragment directive state</dfn>:</p>
-     <ul>
-      <li data-md>
-       <p>Switching on <a href="https://url.spec.whatwg.org/#c">c</a>:</p>
-       <ul>
-        <li data-md>
-         <p>The EOF code point: Do nothing</p>
-        <li data-md>
-         <p>U+0000 NULL: Validation error</p>
-        <li data-md>
-         <p>Otherwise:</p>
-         <ol>
-          <li data-md>
-           <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is not a URL code point and not U+0025 (%),
-validation error.</p>
-          <li data-md>
-           <p>If <a href="https://url.spec.whatwg.org/#c">c</a> is U+0025 (%) and <a href="https://url.spec.whatwg.org/#remaining">remaining</a> does not start with two ASCII hex digits, validation error.</p>
-          <li data-md>
-           <p>UTF-8 percent encode <a href="https://url.spec.whatwg.org/#c">c</a> using the fragment
-percent-encode set and append the result to <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive">URL’s fragment
-directive</a>.</p>
-         </ol>
-       </ul>
-     </ul>
-   </ul>
-   <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive
-  delimiter</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> includes all characters that follow,
-  but not including, the delimiter. </div>
-   <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
-the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> is the string
-"text=foo". </div>
-   <h4 class="heading settled" data-level="2.2.2" id="serializing-the-fragment-directive"><span class="secno">2.2.2. </span><span class="content">Serializing the fragment directive</span><a class="self-link" href="#serializing-the-fragment-directive"></a></h4>
-   <p>Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer </a> steps by inserting a step after step 7:</p>
-   <ol start="8">
-    <li data-md>
-     <p>If the <em>exclude fragment flag</em> is unset and <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive①">URL’s fragment
-directive</a> is non-null:</p>
-     <ol>
-      <li data-md>
-       <p>If <a href="https://url.spec.whatwg.org/#concept-url-fragment">url’s fragment</a> is null, append U+0023 (#)
-to <em>output</em>.</p>
-      <li data-md>
-       <p>Append ":~:", followed by <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive②">URL’s fragment directive</a>, to <em>output</em>.</p>
-     </ol>
-   </ol>
-   <h4 class="heading settled" data-level="2.2.3" id="processing-the-fragment-directive"><span class="secno">2.2.3. </span><span class="content">Processing the fragment directive</span><a class="self-link" href="#processing-the-fragment-directive"></a></h4>
-   <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document-type">Document</a>, add:</p>
-   <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="Document’s fragment directive" data-noexport id="documents-fragment-directive">fragment
-directive</dfn>. </em></p>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to store and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> from the Document’s <a href="https://dom.spec.whatwg.org/#concept-document-url">URL</a>.</p>
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to parse and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> from the Document’s <a href="https://dom.spec.whatwg.org/#concept-document-url">URL</a>.</p>
    <p>Replace steps 7 and 8 of this algorithm with:</p>
    <ol start="7">
     <li data-md>
@@ -1729,22 +1657,67 @@ directive</dfn>. </em></p>
     <li data-md>
      <p>Otherwise, set <em>url</em> to <em>response</em>’s <a href="https://fetch.spec.whatwg.org/#concept-response-url">URL</a>.</p>
     <li data-md>
-     <p>Set <a data-link-type="dfn" href="#documents-fragment-directive" id="ref-for-documents-fragment-directive">Document’s fragment directive</a> to <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive③">URL’s fragment directive</a>.
-(Note: this is stored on the document but not web-exposed)</p>
+     <p>Let <em>raw fragment</em> be equal to <em>url</em>’s <a href="https://url.spec.whatwg.org/#concept-url-fragment">fragment</a>.</p>
     <li data-md>
-     <p>Set <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive④">URL’s fragment directive</a> to null.</p>
+     <p>Let <em>fragment directive position</em> be a <a href="https://infra.spec.whatwg.org/#string-position-variable">position variable</a> that points to the
+beginning of <em>raw fragment</em>.</p>
+    <li data-md>
+     <p>While the string starting at position <em>fragment directive position</em> does not start with the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive delimiter</a> and <em>fragment
+directive position</em> does not point past the end of <em>raw fragment</em>:</p>
+     <ol>
+      <li data-md>
+       <p>Advance <em>fragment directive position</em> by 1.</p>
+     </ol>
+    <li data-md>
+     <p>If <em>fragment directive position</em> does not point past the end of <em>raw fragment</em>:</p>
+     <ol>
+      <li data-md>
+       <p>Let <em>fragment</em> be the substring of <em>raw fragment</em> ending at <em>fragment directive position</em>.</p>
+      <li data-md>
+       <p>Advance <em>fragment directive position</em> by the length of <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment
+directive delimiter</a>.</p>
+      <li data-md>
+       <p>Let <em>fragment directive</em> be the substring of <em>raw fragment</em> starting at <em>fragment directive position</em>.</p>
+      <li data-md>
+       <p>Set <em>url</em>’s <a href="https://url.spec.whatwg.org/#concept-url-fragment">fragment</a> to <em>fragment</em>.</p>
+      <li data-md>
+       <p>Set <em>document</em>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> to <em>fragment
+directive</em>. (Note: this is stored on the document but not
+web-exposed)</p>
+     </ol>
     <li data-md>
      <p>Set <em>document</em>’s <a href="https://dom.spec.whatwg.org/#concept-document-url">URL</a> to be <em>url</em>.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.2.4" id="fragment-directive-grammar"><span class="secno">2.2.4. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
+   <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive
+  delimiter</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> includes all characters that follow,
+  but not including, the delimiter. </div>
+   <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
+the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> is the string
+"text=foo". </div>
+   <h4 class="heading settled" data-level="2.2.2" id="serializing-the-fragment-directive"><span class="secno">2.2.2. </span><span class="content">Serializing the fragment directive</span><a class="self-link" href="#serializing-the-fragment-directive"></a></h4>
+   <p>Amend the <a href="https://url.spec.whatwg.org/#url-serializing">URL serializer </a> steps by inserting a step after step 7:</p>
+   <ol start="8">
+    <li data-md>
+     <p>If the <em>exclude fragment flag</em> is unset and <em>url</em> has an
+associated Document <em>document</em> and <em>document</em>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment
+directive</a> is non-null:</p>
+     <ol>
+      <li data-md>
+       <p>If <em>url</em>’s <a href="https://url.spec.whatwg.org/#concept-url-fragment">fragment</a> is null, append
+U+0023 (#) to <em>output</em>.</p>
+      <li data-md>
+       <p>Append ":~:", followed by <em>document</em>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a>, to <em>output</em>.</p>
+     </ol>
+   </ol>
+   <h4 class="heading settled" data-level="2.2.3" id="fragment-directive-grammar"><span class="secno">2.2.3. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
     A <dfn data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive<a class="self-link" href="#valid-fragment-directive"></a></dfn> is a sequence of characters that appears
-in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a> that matches the production: 
+in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a> that matches the production: 
    <dl> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirective">FragmentDirective</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> ("&amp;" <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a>)*</dd></code> </dl>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective">FragmentDirective</a> may contain multiple directives split by the "&amp;"
 character. Currently this means we allow multiple text directives to enable
 multiple indicated strings in the page, but this also allows for future
 directive types to be added and combined. </div>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> that
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> that
 enables specifying a piece of text on the page, that matches the production:</p>
    <dl>
      <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt><dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></dd></code> 
@@ -1836,7 +1809,7 @@ the element fragment as the indicated part of the document. </div>
    <p>Add the following steps to the beginning of the processing model for <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document"> The indicated part of the document</a>.</p>
    <ol>
     <li data-md>
-     <p>Let <em>fragment directive string</em> be the document <a data-link-type="dfn" href="#urls-fragment-directive" id="ref-for-urls-fragment-directive⑤">URL’s fragment
+     <p>Let <em>fragment directive string</em> be the <em>document</em>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment
 directive</a>.</p>
     <li data-md>
      <p>Let <em>is user activated</em> be true if the current navigation was <a href="https://html.spec.whatwg.org/#triggered-by-user-activation"> triggered
@@ -2354,28 +2327,25 @@ manipulations
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#current-locale">current locale</a><span>, in §2.4.2</span>
-   <li><a href="#documents-fragment-directive">Document’s fragment directive</a><span>, in §2.2.3</span>
    <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §2.6</span>
    <li><a href="#fragment-directive">fragment directive</a><span>, in §2.2.1</span>
    <li>
     FragmentDirective
     <ul>
      <li><a href="#fragmentdirective①">(interface)</a><span>, in §2.6</span>
-     <li><a href="#fragmentdirective">definition of</a><span>, in §2.2.4</span>
+     <li><a href="#fragmentdirective">definition of</a><span>, in §2.2.3</span>
     </ul>
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §2.2.1</span>
-   <li><a href="#fragment-directive-state">fragment directive state</a><span>, in §2.2.1</span>
    <li><a href="#location">Location</a><span>, in §2.6</span>
-   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §2.2.4</span>
-   <li><a href="#textdirective">TextDirective</a><span>, in §2.2.4</span>
-   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §2.2.4</span>
-   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §2.2.4</span>
-   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §2.2.4</span>
-   <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §2.2.4</span>
-   <li><a href="#textmatchchar">TextMatchChar</a><span>, in §2.2.4</span>
-   <li><a href="#textmatchstring">TextMatchString</a><span>, in §2.2.4</span>
-   <li><a href="#urls-fragment-directive">URL’s fragment directive</a><span>, in §2.2.1</span>
-   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §2.2.4</span>
+   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §2.2.3</span>
+   <li><a href="#textdirective">TextDirective</a><span>, in §2.2.3</span>
+   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §2.2.3</span>
+   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §2.2.3</span>
+   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §2.2.3</span>
+   <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §2.2.3</span>
+   <li><a href="#textmatchchar">TextMatchChar</a><span>, in §2.2.3</span>
+   <li><a href="#textmatchstring">TextMatchString</a><span>, in §2.2.3</span>
+   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §2.2.3</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -2392,13 +2362,15 @@ manipulations
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="urls-fragment-directive">
-   <b><a href="#urls-fragment-directive">#urls-fragment-directive</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="fragment-directive">
+   <b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-urls-fragment-directive">2.2.1. Parsing the fragment directive</a>
-    <li><a href="#ref-for-urls-fragment-directive①">2.2.2. Serializing the fragment directive</a> <a href="#ref-for-urls-fragment-directive②">(2)</a>
-    <li><a href="#ref-for-urls-fragment-directive③">2.2.3. Processing the fragment directive</a> <a href="#ref-for-urls-fragment-directive④">(2)</a>
-    <li><a href="#ref-for-urls-fragment-directive⑤">2.4. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-fragment-directive">2.1. Syntax</a>
+    <li><a href="#ref-for-fragment-directive①">2.2. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a>
+    <li><a href="#ref-for-fragment-directive④">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a> <a href="#ref-for-fragment-directive⑨">(6)</a>
+    <li><a href="#ref-for-fragment-directive①⓪">2.2.2. Serializing the fragment directive</a> <a href="#ref-for-fragment-directive①①">(2)</a>
+    <li><a href="#ref-for-fragment-directive①②">2.2.3. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①③">(2)</a>
+    <li><a href="#ref-for-fragment-directive①④">2.4. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragment-directive-delimiter">
@@ -2407,32 +2379,10 @@ manipulations
     <li><a href="#ref-for-fragment-directive-delimiter">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter①">(2)</a> <a href="#ref-for-fragment-directive-delimiter②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragment-directive">
-   <b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-fragment-directive">2.1. Syntax</a>
-    <li><a href="#ref-for-fragment-directive①">2.2. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a>
-    <li><a href="#ref-for-fragment-directive④">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a>
-    <li><a href="#ref-for-fragment-directive⑨">2.2.3. Processing the fragment directive</a>
-    <li><a href="#ref-for-fragment-directive①⓪">2.2.4. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="fragment-directive-state">
-   <b><a href="#fragment-directive-state">#fragment-directive-state</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-fragment-directive-state">2.2.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive-state①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="documents-fragment-directive">
-   <b><a href="#documents-fragment-directive">#documents-fragment-directive</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-documents-fragment-directive">2.2.3. Processing the fragment directive</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="fragmentdirective">
    <b><a href="#fragmentdirective">#fragmentdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragmentdirective">2.2.4. Fragment directive grammar</a>
+    <li><a href="#ref-for-fragmentdirective">2.2.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="text-fragment-directive">
@@ -2451,43 +2401,43 @@ manipulations
   <aside class="dfn-panel" data-for="textdirective">
    <b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirective">2.2.4. Fragment directive grammar</a> <a href="#ref-for-textdirective①">(2)</a> <a href="#ref-for-textdirective②">(3)</a>
+    <li><a href="#ref-for-textdirective">2.2.3. Fragment directive grammar</a> <a href="#ref-for-textdirective①">(2)</a> <a href="#ref-for-textdirective②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveparameters">
    <b><a href="#textdirectiveparameters">#textdirectiveparameters</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectiveparameters">2.2.4. Fragment directive grammar</a>
+    <li><a href="#ref-for-textdirectiveparameters">2.2.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveprefix">
    <b><a href="#textdirectiveprefix">#textdirectiveprefix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectiveprefix">2.2.4. Fragment directive grammar</a>
+    <li><a href="#ref-for-textdirectiveprefix">2.2.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectivesuffix">
    <b><a href="#textdirectivesuffix">#textdirectivesuffix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectivesuffix">2.2.4. Fragment directive grammar</a>
+    <li><a href="#ref-for-textdirectivesuffix">2.2.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textmatchstring">
    <b><a href="#textmatchstring">#textmatchstring</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textmatchstring">2.2.4. Fragment directive grammar</a> <a href="#ref-for-textmatchstring①">(2)</a> <a href="#ref-for-textmatchstring②">(3)</a> <a href="#ref-for-textmatchstring③">(4)</a>
+    <li><a href="#ref-for-textmatchstring">2.2.3. Fragment directive grammar</a> <a href="#ref-for-textmatchstring①">(2)</a> <a href="#ref-for-textmatchstring②">(3)</a> <a href="#ref-for-textmatchstring③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textmatchchar">
    <b><a href="#textmatchchar">#textmatchchar</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textmatchchar">2.2.4. Fragment directive grammar</a> <a href="#ref-for-textmatchchar①">(2)</a>
+    <li><a href="#ref-for-textmatchchar">2.2.3. Fragment directive grammar</a> <a href="#ref-for-textmatchchar①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="percentencodedchar">
    <b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-percentencodedchar">2.2.4. Fragment directive grammar</a>
+    <li><a href="#ref-for-percentencodedchar">2.2.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="current-locale">


### PR DESCRIPTION
This patch moves the fragment directive parsing steps out of the URL parser and into the document initialization steps.

One caveat is that the URL serialization can no longer refer to the URL's stored fragment directive. My solution is to refer to the "associated Document"'s fragment directive, but I'm open to other ideas here.

Fixes #60 