### PR TITLE
Specify how a Range is the indicated part of the document

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -320,8 +320,8 @@ The scroll to text specification proposes an amendment to
 [[html#scroll-to-fragid]]. In summary, if a [=text fragment directive=] is
 present and a match is found in the page, the text fragment takes precedent over
 the element fragment as the indicated part of the document. We amend the
-indicated part of the document to possibly include a [[DOM#range|Range]] that is
-scrolled into view instead of the containing element.
+indicated part of the document to optionally include a [[DOM#range|Range]] that
+is scrolled into view instead of the containing element.
 </div>
 
 Replace step 3.1 of the [[HTML#scroll-to-the-fragment-identifier|scroll to the
@@ -337,8 +337,8 @@ fragment]] algorithm with the following:
 3. Otherwise:
     3. If <em>range</em> is non-null:
         1. [=scroll a Range into view|Scroll range into view=], with
-            <em>behavior</em> set to "auto", <em>block</em> set to "start", and
-            <em>inline</em> set to "nearest".
+            containingElement <em>target</em>, <em>behavior</em> set to "auto",
+            <em>block</em> set to "start", and <em>inline</em> set to "nearest".
     4. Otherwise:
         1. [[cssom-view#scroll-an-element-into-view|Scroll target into view]],
             with <em>behavior</em> set to "auto", <em>block</em> set to "start",
@@ -385,21 +385,26 @@ Move the [[cssom-view#scroll-an-element-into-view|scroll an element into
 view]] algorithm's steps 3-14 into a new algorithm <dfn>scroll a DOMRect into
 view</dfn>, with input <a
 href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> <em>bounding
-border box</em> and
-[[cssom-view#dictdef-scrollintoviewoptions|ScrollIntoViewOptions]] dictionary
-<em>options</em>.
+box</em>, [[cssom-view#dictdef-scrollintoviewoptions|ScrollIntoViewOptions]]
+dictionary <em>options</em>, and [[DOM#element|Element]]
+<em>startingElement</em>. Also move the recursive behavior described at the top
+of the [[cssom-view#scroll-an-element-into-view|scroll an element into view]]
+algorithm to the [=scroll a DOMRect into view=] algorithm: "run these steps for
+each ancestor element or viewport <b>of <em>startingElement</em></b> that
+establishes a scrolling box <em>scrolling box</em>, in order of innermost to
+outermost scrolling box".
 <div class="note">
-<em>bounding border box</em> is renamed from <em>element bounding border
-box</em>.
+<em>bounding box</em> is renamed from <em>element bounding border box</em>.
 </div>
 
 Replace steps 3-14 of the [[cssom-view#scroll-an-element-into-view|scroll an
 element into view]] algorithm with a call to [=scroll a DOMRect into view=]:
 3. Perform [=scroll a DOMRect into view=] on <em>element bounding border
-    box</em> with <em>options</em>.
+    box</em> with options <em>options</em> and startingElement <em>element</em>.
 
 Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
-[[DOM#range|Range]] <em>range</em> and a
+[[DOM#range|Range]] <em>range</em>, [[DOM#element|Element]]
+<em>containingElement</em>, and a
 [[cssom-view#dictdef-scrollintoviewoptions|ScrollIntoViewOptions]] dictionary
 <em>options</em>:
 1. Let <em>bounding rect</em> be the <a
@@ -408,7 +413,7 @@ Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
     [[cssom-view#dom-range-getboundingclientrect|getBoundingClientRect()]]
     on <em>range</em>.
 2. Perform [=scroll a DOMRect into view=] on <em>bounding rect</em> with
-    <em>options</em>.
+    <em>options</em> and startingElement <em>containingElement</em>.
 
 ### Find a target text ### {#find-a-target-text}
 

--- a/index.bs
+++ b/index.bs
@@ -319,12 +319,36 @@ invoke.
 The scroll to text specification proposes an amendment to
 [[html#scroll-to-fragid]]. In summary, if a [=text fragment directive=] is
 present and a match is found in the page, the text fragment takes precedent over
-the element fragment as the indicated part of the document.
+the element fragment as the indicated part of the document. We amend the
+indicated part of the document to possibly include a [[DOM#range|Range]] that is
+scrolled into view instead of the containing element.
 </div>
 
-Add the following steps to the beginning of the processing model for <a
-href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">
-The indicated part of the document</a>.
+Replace step 3.1 of the [[HTML#scroll-to-the-fragment-identifier|scroll to the
+fragment]] algorithm with the following:
+3. Otherwise:
+    1. Let <em>target, range</em> be the [[DOM#element|Element]] and
+        [[DOM#range|Range]] that is
+        [[HTML#the-indicated-part-of-the-document|the indicated part of the
+        document]].
+
+Replace step 3.3 of the [[HTML#scroll-to-the-fragment-identifier|scroll to the
+fragment]] algorithm with the following:
+3. Otherwise:
+    3. If <em>range</em> is non-null:
+        1. [=scroll a Range into view|Scroll range into view=], with
+            <em>behavior</em> set to "auto", <em>block</em> set to "start", and
+            <em>inline</em> set to "nearest".
+    4. Otherwise:
+        1. [[cssom-view#scroll-an-element-into-view|Scroll target into view]],
+            with <em>behavior</em> set to "auto", <em>block</em> set to "start",
+            and <em>inline</em> set to "nearest".
+            <div class="note">This otherwise case is the same as the current
+            step 3.3.</div>
+
+
+Add the following steps to the beginning of the processing model for
+[[HTML#the-indicated-part-of-the-document|the indicated part of the document]]:
 
 1. Let <em>fragment directive string</em> be the <em>document</em>'s [=fragment
     directive=].
@@ -337,9 +361,54 @@ The indicated part of the document</a>.
     </div>
 3. If the result of [[#should-allow-text-fragment]] with the window of the
     document's browsing context and <em>is user activated</em> is true then:
-    1. If [[#find-a-target-text]] with <em>fragment directive string</em>
-        returns non-null, then the return value is the indicated part of the
-        document; return.
+    1. Let <em>range</em> be the result of [[#find-a-target-text]] with
+        <em>fragment directive string</em>.
+    2. If <em>range</em> is non-null, then:
+        1. Let <em>node</em> be <em>range</em>'s
+            [[DOM#dom-range-commonancestorcontainer|commonAncestorContainer]].
+        2. While <em>node</em>'s [[DOM#dom-node-nodetype|nodeType]] is not
+            [[DOM#dom-node-element_node|ELEMENT_NODE]]:
+            1. Set <em>node</em> to <em>node</em>'s
+                [[DOM#dom-node-parentnode|parentNode]].
+        3. The indicated part of the document is <em>node</em> and
+            <em>range</em>; return.
+
+### Scroll a DOMRect into view ### {#scroll-rect-into-view}
+<div class="note">
+This section describes a refactoring of the CSSOMVIEW's
+[[cssom-view#scroll-an-element-into-view|scroll an element into view]] algorithm 
+to separate the steps for scrolling a DOMRect into view, so it can be used to
+scroll a Range into view.
+</div>
+
+Move the [[cssom-view#scroll-an-element-into-view|scroll an element into
+view]] algorithm's steps 3-14 into a new algorithm <dfn>scroll a DOMRect into
+view</dfn>, with input <a
+href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> <em>bounding
+border box</em> and
+[[cssom-view#dictdef-scrollintoviewoptions|ScrollIntoViewOptions]] dictionary
+<em>options</em>.
+<div class="note">
+<em>bounding border box</em> is renamed from <em>element bounding border
+box</em>.
+</div>
+
+Replace steps 3-14 of the [[cssom-view#scroll-an-element-into-view|scroll an
+element into view]] algorithm with a call to [=scroll a DOMRect into view=]:
+3. Perform [=scroll a DOMRect into view=] on <em>element bounding border
+    box</em> with <em>options</em>.
+
+Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
+[[DOM#range|Range]] <em>range</em> and a
+[[cssom-view#dictdef-scrollintoviewoptions|ScrollIntoViewOptions]] dictionary
+<em>options</em>:
+1. Let <em>bounding rect</em> be the <a
+    href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> that is
+    the return value of invoking
+    [[cssom-view#dom-range-getboundingclientrect|getBoundingClientRect()]]
+    on <em>range</em>.
+2. Perform [=scroll a DOMRect into view=] on <em>bounding rect</em> with
+    <em>options</em>.
 
 ### Find a target text ### {#find-a-target-text}
 

--- a/index.bs
+++ b/index.bs
@@ -338,7 +338,7 @@ fragment]] algorithm with the following:
     3. If <em>range</em> is non-null:
         1. [=scroll a Range into view|Scroll range into view=], with
             containingElement <em>target</em>, <em>behavior</em> set to "auto",
-            <em>block</em> set to "start", and <em>inline</em> set to "nearest".
+            <em>block</em> set to "center", and <em>inline</em> set to "nearest".
     4. Otherwise:
         1. [[cssom-view#scroll-an-element-into-view|Scroll target into view]],
             with <em>behavior</em> set to "auto", <em>block</em> set to "start",

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version f5a6d58a6b9207b620f985d7239601eb3a483162" name="generator">
+  <meta content="Bikeshed version 2dbd5e1f0bb11704a5d90167ddaef9475f9c26b3" name="generator">
   <link href="wicg.github.io/ScrollToTextFragment/index.html" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-11-04">4 November 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-11-05">5 November 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1791,8 +1791,8 @@ document.</p>
    <div class="note" role="note"> The scroll to text specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.8.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑦">text fragment directive</a> is
 present and a match is found in the page, the text fragment takes precedent over
 the element fragment as the indicated part of the document. We amend the
-indicated part of the document to possibly include a <a href="https://dom.spec.whatwg.org/#range">Range</a> that is
-scrolled into view instead of the containing element. </div>
+indicated part of the document to optionally include a <a href="https://dom.spec.whatwg.org/#range">Range</a> that
+is scrolled into view instead of the containing element. </div>
    <p>Replace step 3.1 of the <a href="https://html.spec.whatwg.org/multipage/#scroll-to-the-fragment-identifier">scroll to the
 fragment</a> algorithm with the following:</p>
    <ol start="3">
@@ -1814,7 +1814,8 @@ fragment</a> algorithm with the following:</p>
        <p>If <em>range</em> is non-null:</p>
        <ol>
         <li data-md>
-         <p><a data-link-type="dfn" href="#scroll-a-range-into-view" id="ref-for-scroll-a-range-into-view">Scroll range into view</a>, with <em>behavior</em> set to "auto", <em>block</em> set to "start", and <em>inline</em> set to "nearest".</p>
+         <p><a data-link-type="dfn" href="#scroll-a-range-into-view" id="ref-for-scroll-a-range-into-view">Scroll range into view</a>, with
+containingElement <em>target</em>, <em>behavior</em> set to "auto", <em>block</em> set to "start", and <em>inline</em> set to "nearest".</p>
        </ol>
       <li data-md>
        <p>Otherwise:</p>
@@ -1867,23 +1868,26 @@ scroll a Range into view. </div>
    <p>Move the <a href="https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view">scroll an element into
 view</a> algorithm’s steps 3-14 into a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="scroll a DOMRect into view" data-noexport id="scroll-a-domrect-into-view">scroll a DOMRect into
 view</dfn>, with input <a href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> <em>bounding
-border box</em> and <a href="https://www.w3.org/TR/cssom-view-1/#dictdef-scrollintoviewoptions">ScrollIntoViewOptions</a> dictionary <em>options</em>.</p>
-   <div class="note" role="note"> <em>bounding border box</em> is renamed from <em>element bounding border
-box</em>. </div>
+box</em>, <a href="https://www.w3.org/TR/cssom-view-1/#dictdef-scrollintoviewoptions">ScrollIntoViewOptions</a> dictionary <em>options</em>, and <a href="https://dom.spec.whatwg.org/#element">Element</a> <em>startingElement</em>. Also move the recursive behavior described at the top
+of the <a href="https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view">scroll an element into view</a> algorithm to the <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view">scroll a DOMRect into view</a> algorithm: "run these steps for
+each ancestor element or viewport <b>of <em>startingElement</em></b> that
+establishes a scrolling box <em>scrolling box</em>, in order of innermost to
+outermost scrolling box".</p>
+   <div class="note" role="note"> <em>bounding box</em> is renamed from <em>element bounding border box</em>. </div>
    <p>Replace steps 3-14 of the <a href="https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view">scroll an
-element into view</a> algorithm with a call to <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view">scroll a DOMRect into view</a>:</p>
+element into view</a> algorithm with a call to <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view①">scroll a DOMRect into view</a>:</p>
    <ol start="3">
     <li data-md>
-     <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view①">scroll a DOMRect into view</a> on <em>element bounding border
-box</em> with <em>options</em>.</p>
+     <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view②">scroll a DOMRect into view</a> on <em>element bounding border
+box</em> with options <em>options</em> and startingElement <em>element</em>.</p>
    </ol>
-   <p>Define a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-range-into-view">scroll a Range into view</dfn>, with input <a href="https://dom.spec.whatwg.org/#range">Range</a> <em>range</em> and a <a href="https://www.w3.org/TR/cssom-view-1/#dictdef-scrollintoviewoptions">ScrollIntoViewOptions</a> dictionary <em>options</em>:</p>
+   <p>Define a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-range-into-view">scroll a Range into view</dfn>, with input <a href="https://dom.spec.whatwg.org/#range">Range</a> <em>range</em>, <a href="https://dom.spec.whatwg.org/#element">Element</a> <em>containingElement</em>, and a <a href="https://www.w3.org/TR/cssom-view-1/#dictdef-scrollintoviewoptions">ScrollIntoViewOptions</a> dictionary <em>options</em>:</p>
    <ol>
     <li data-md>
      <p>Let <em>bounding rect</em> be the <a href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> that is
 the return value of invoking <a href="https://www.w3.org/TR/cssom-view-1/#dom-range-getboundingclientrect">getBoundingClientRect()</a> on <em>range</em>.</p>
     <li data-md>
-     <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view②">scroll a DOMRect into view</a> on <em>bounding rect</em> with <em>options</em>.</p>
+     <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view③">scroll a DOMRect into view</a> on <em>bounding rect</em> with <em>options</em> and startingElement <em>containingElement</em>.</p>
    </ol>
    <h4 class="heading settled" data-level="2.4.2" id="find-a-target-text"><span class="secno">2.4.2. </span><span class="content">Find a target text</span><a class="self-link" href="#find-a-target-text"></a></h4>
    <p>To find the target text for a given string <em>fragment directive input</em>,
@@ -2504,7 +2508,7 @@ manipulations
   <aside class="dfn-panel" data-for="scroll-a-domrect-into-view">
    <b><a href="#scroll-a-domrect-into-view">#scroll-a-domrect-into-view</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scroll-a-domrect-into-view">2.4.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-a-domrect-into-view①">(2)</a> <a href="#ref-for-scroll-a-domrect-into-view②">(3)</a>
+    <li><a href="#ref-for-scroll-a-domrect-into-view">2.4.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-a-domrect-into-view①">(2)</a> <a href="#ref-for-scroll-a-domrect-into-view②">(3)</a> <a href="#ref-for-scroll-a-domrect-into-view③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="scroll-a-range-into-view">

--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 0e7769cca82774609b9dc8700c9a84ef436a1a12" name="generator">
+  <meta content="Bikeshed version f5a6d58a6b9207b620f985d7239601eb3a483162" name="generator">
   <link href="wicg.github.io/ScrollToTextFragment/index.html" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Scroll To Text Fragment</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-10-28">28 October 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-11-04">4 November 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1534,10 +1534,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>
        <a href="#navigating-to-text-fragment"><span class="secno">2.4</span> <span class="content">Navigating to a Text Fragment</span></a>
        <ol class="toc">
-        <li><a href="#find-a-target-text"><span class="secno">2.4.1</span> <span class="content">Find a target text</span></a>
-        <li><a href="#find-match-with-context"><span class="secno">2.4.2</span> <span class="content">Find an exact match with context</span></a>
-        <li><a href="#advance-walker-to-text"><span class="secno">2.4.3</span> <span class="content">Advance a TreeWalker to the next text node</span></a>
-        <li><a href="#next-word-bounded-instance"><span class="secno">2.4.4</span> <span class="content">Find the next word bounded instance</span></a>
+        <li><a href="#scroll-rect-into-view"><span class="secno">2.4.1</span> <span class="content">Scroll a DOMRect into view</span></a>
+        <li><a href="#find-a-target-text"><span class="secno">2.4.2</span> <span class="content">Find a target text</span></a>
+        <li><a href="#find-match-with-context"><span class="secno">2.4.3</span> <span class="content">Find an exact match with context</span></a>
+        <li><a href="#advance-walker-to-text"><span class="secno">2.4.4</span> <span class="content">Advance a TreeWalker to the next text node</span></a>
+        <li><a href="#next-word-bounded-instance"><span class="secno">2.4.5</span> <span class="content">Find the next word bounded instance</span></a>
        </ol>
       <li><a href="#indicating-the-text-match"><span class="secno">2.5</span> <span class="content">Indicating The Text Match</span></a>
       <li><a href="#feature-detectability"><span class="secno">2.6</span> <span class="content">Feature Detectability</span></a>
@@ -1762,7 +1763,7 @@ the existence of a text snippet by measuring how long the navigation call takes.
    <p>For this reason, the implementation <em>must ensure the runtime of <a href="#navigating-to-text-fragment">§ 2.4 Navigating to a Text Fragment</a> steps does not differ based on whether a match
 has been successfully found</em>.</p>
    <p>This specification does not specify exactly how a UA achieves this as there are
-multiple solutions with differing tradeoffs. For example, a UA <em>may</em> continue to walk the tree even after a match is found in <a href="#find-a-target-text">§ 2.4.1 Find a target text</a>.  Alternatively, it <em>may</em> schedule an
+multiple solutions with differing tradeoffs. For example, a UA <em>may</em> continue to walk the tree even after a match is found in <a href="#find-a-target-text">§ 2.4.2 Find a target text</a>.  Alternatively, it <em>may</em> schedule an
 asynchronous task to find and set the indicated part of the document.</p>
    <h4 class="heading settled" data-level="2.3.3" id="should-allow-text-fragment"><span class="secno">2.3.3. </span><span class="content">Should Allow Text Fragment</span><a class="self-link" href="#should-allow-text-fragment"></a></h4>
    <div class="note" role="note"> This algorithm has input <em>window, is user triggered</em> and returns a
@@ -1789,8 +1790,45 @@ document.</p>
    <h3 class="heading settled" data-level="2.4" id="navigating-to-text-fragment"><span class="secno">2.4. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
    <div class="note" role="note"> The scroll to text specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.8.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑦">text fragment directive</a> is
 present and a match is found in the page, the text fragment takes precedent over
-the element fragment as the indicated part of the document. </div>
-   <p>Add the following steps to the beginning of the processing model for <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document"> The indicated part of the document</a>.</p>
+the element fragment as the indicated part of the document. We amend the
+indicated part of the document to possibly include a <a href="https://dom.spec.whatwg.org/#range">Range</a> that is
+scrolled into view instead of the containing element. </div>
+   <p>Replace step 3.1 of the <a href="https://html.spec.whatwg.org/multipage/#scroll-to-the-fragment-identifier">scroll to the
+fragment</a> algorithm with the following:</p>
+   <ol start="3">
+    <li data-md>
+     <p>Otherwise:</p>
+     <ol>
+      <li data-md>
+       <p>Let <em>target, range</em> be the <a href="https://dom.spec.whatwg.org/#element">Element</a> and <a href="https://dom.spec.whatwg.org/#range">Range</a> that is <a href="https://html.spec.whatwg.org/multipage/#the-indicated-part-of-the-document">the indicated part of the
+document</a>.</p>
+     </ol>
+   </ol>
+   <p>Replace step 3.3 of the <a href="https://html.spec.whatwg.org/multipage/#scroll-to-the-fragment-identifier">scroll to the
+fragment</a> algorithm with the following:</p>
+   <ol start="3">
+    <li data-md>
+     <p>Otherwise:</p>
+     <ol start="3">
+      <li data-md>
+       <p>If <em>range</em> is non-null:</p>
+       <ol>
+        <li data-md>
+         <p><a data-link-type="dfn" href="#scroll-a-range-into-view" id="ref-for-scroll-a-range-into-view">Scroll range into view</a>, with <em>behavior</em> set to "auto", <em>block</em> set to "start", and <em>inline</em> set to "nearest".</p>
+       </ol>
+      <li data-md>
+       <p>Otherwise:</p>
+       <ol>
+        <li data-md>
+         <p><a href="https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view">Scroll target into view</a>,
+with <em>behavior</em> set to "auto", <em>block</em> set to "start",
+and <em>inline</em> set to "nearest".</p>
+         <div class="note" role="note">This otherwise case is the same as the current
+step 3.3.</div>
+       </ol>
+     </ol>
+   </ol>
+   <p>Add the following steps to the beginning of the processing model for <a href="https://html.spec.whatwg.org/multipage/#the-indicated-part-of-the-document">the indicated part of the document</a>:</p>
    <ol>
     <li data-md>
      <p>Let <em>fragment directive string</em> be the <em>document</em>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment
@@ -1805,11 +1843,49 @@ activation triggering </div>
 document’s browsing context and <em>is user activated</em> is true then:</p>
      <ol>
       <li data-md>
-       <p>If <a href="#find-a-target-text">§ 2.4.1 Find a target text</a> with <em>fragment directive string</em> returns non-null, then the return value is the indicated part of the
-document; return.</p>
+       <p>Let <em>range</em> be the result of <a href="#find-a-target-text">§ 2.4.2 Find a target text</a> with <em>fragment directive string</em>.</p>
+      <li data-md>
+       <p>If <em>range</em> is non-null, then:</p>
+       <ol>
+        <li data-md>
+         <p>Let <em>node</em> be <em>range</em>’s <a href="https://dom.spec.whatwg.org/#dom-range-commonancestorcontainer">commonAncestorContainer</a>.</p>
+        <li data-md>
+         <p>While <em>node</em>’s <a href="https://dom.spec.whatwg.org/#dom-node-nodetype">nodeType</a> is not <a href="https://dom.spec.whatwg.org/#dom-node-element_node">ELEMENT_NODE</a>:</p>
+         <ol>
+          <li data-md>
+           <p>Set <em>node</em> to <em>node</em>’s <a href="https://dom.spec.whatwg.org/#dom-node-parentnode">parentNode</a>.</p>
+         </ol>
+        <li data-md>
+         <p>The indicated part of the document is <em>node</em> and <em>range</em>; return.</p>
+       </ol>
      </ol>
    </ol>
-   <h4 class="heading settled" data-level="2.4.1" id="find-a-target-text"><span class="secno">2.4.1. </span><span class="content">Find a target text</span><a class="self-link" href="#find-a-target-text"></a></h4>
+   <h4 class="heading settled" data-level="2.4.1" id="scroll-rect-into-view"><span class="secno">2.4.1. </span><span class="content">Scroll a DOMRect into view</span><a class="self-link" href="#scroll-rect-into-view"></a></h4>
+   <div class="note" role="note"> This section describes a refactoring of the CSSOMVIEW’s <a href="https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view">scroll an element into view</a> algorithm 
+to separate the steps for scrolling a DOMRect into view, so it can be used to
+scroll a Range into view. </div>
+   <p>Move the <a href="https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view">scroll an element into
+view</a> algorithm’s steps 3-14 into a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="scroll a DOMRect into view" data-noexport id="scroll-a-domrect-into-view">scroll a DOMRect into
+view</dfn>, with input <a href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> <em>bounding
+border box</em> and <a href="https://www.w3.org/TR/cssom-view-1/#dictdef-scrollintoviewoptions">ScrollIntoViewOptions</a> dictionary <em>options</em>.</p>
+   <div class="note" role="note"> <em>bounding border box</em> is renamed from <em>element bounding border
+box</em>. </div>
+   <p>Replace steps 3-14 of the <a href="https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view">scroll an
+element into view</a> algorithm with a call to <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view">scroll a DOMRect into view</a>:</p>
+   <ol start="3">
+    <li data-md>
+     <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view①">scroll a DOMRect into view</a> on <em>element bounding border
+box</em> with <em>options</em>.</p>
+   </ol>
+   <p>Define a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-range-into-view">scroll a Range into view</dfn>, with input <a href="https://dom.spec.whatwg.org/#range">Range</a> <em>range</em> and a <a href="https://www.w3.org/TR/cssom-view-1/#dictdef-scrollintoviewoptions">ScrollIntoViewOptions</a> dictionary <em>options</em>:</p>
+   <ol>
+    <li data-md>
+     <p>Let <em>bounding rect</em> be the <a href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> that is
+the return value of invoking <a href="https://www.w3.org/TR/cssom-view-1/#dom-range-getboundingclientrect">getBoundingClientRect()</a> on <em>range</em>.</p>
+    <li data-md>
+     <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view②">scroll a DOMRect into view</a> on <em>bounding rect</em> with <em>options</em>.</p>
+   </ol>
+   <h4 class="heading settled" data-level="2.4.2" id="find-a-target-text"><span class="secno">2.4.2. </span><span class="content">Find a target text</span><a class="self-link" href="#find-a-target-text"></a></h4>
    <p>To find the target text for a given string <em>fragment directive input</em>,
 the user agent must run these steps:</p>
    <ol>
@@ -1870,7 +1946,7 @@ variable</a> that indicates a text offset in <em>walker.currentNode.innerText</e
      <p>If textEnd is the empty string, then:</p>
      <ol>
       <li data-md>
-       <p>Let <em>match position</em> be the result of <a href="#find-match-with-context">§ 2.4.2 Find an exact match with context</a> with input walker <em>walker</em>, search position <em>position</em>,
+       <p>Let <em>match position</em> be the result of <a href="#find-match-with-context">§ 2.4.3 Find an exact match with context</a> with input walker <em>walker</em>, search position <em>position</em>,
 prefix <em>prefix</em>, query <em>textStart</em>, and suffix <em>suffix</em>.</p>
       <li data-md>
        <p>If <em>match position</em> is null, then return null.</p>
@@ -1881,12 +1957,12 @@ position <em>match position</em> and length equal to the length of <em>textStart
        <p>Return <em>match</em>.</p>
      </ol>
     <li data-md>
-     <p>Otherwise, let <em>potential start position</em> be the result of <a href="#find-match-with-context">§ 2.4.2 Find an exact match with context</a> with input walker <em>walker</em>, start
+     <p>Otherwise, let <em>potential start position</em> be the result of <a href="#find-match-with-context">§ 2.4.3 Find an exact match with context</a> with input walker <em>walker</em>, start
 position <em>position</em>, prefix <em>prefix</em>, query <em>textStart</em>, and suffix <em>null</em>.</p>
     <li data-md>
      <p>If <em>potential start position</em> is null, then return null.</p>
     <li data-md>
-     <p>Let <em>end position</em> be the result of <a href="#find-match-with-context">§ 2.4.2 Find an exact match with context</a> with
+     <p>Let <em>end position</em> be the result of <a href="#find-match-with-context">§ 2.4.3 Find an exact match with context</a> with
 input walker <em>walker</em>, search position <em>potential start
 position</em>, prefix <em>null</em>, query <em>textEnd</em>, and suffix <em>suffix</em>.</p>
     <li data-md>
@@ -1900,7 +1976,7 @@ position - start position</em>.</p>
     <li data-md>
      <p>Return <em>match</em>.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.4.2" id="find-match-with-context"><span class="secno">2.4.2. </span><span class="content">Find an exact match with context</span><a class="self-link" href="#find-match-with-context"></a></h4>
+   <h4 class="heading settled" data-level="2.4.3" id="find-match-with-context"><span class="secno">2.4.3. </span><span class="content">Find an exact match with context</span><a class="self-link" href="#find-match-with-context"></a></h4>
    <div class="note" role="note"> This algorithm has input <em>walker, search position, prefix, query,</em> and <em>suffix</em> and returns a text position that is the start of the match. </div>
    <div class="note" role="note"> The input <em>walker</em> is a <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> reference, not a
 copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
@@ -1920,7 +1996,7 @@ copy, i.e. any modifications are performed on the caller’s instance of <em>wal
          <ol>
           <li data-md>
            <p>Advance <em>search position</em> to the position after the result
-of <a href="#next-word-bounded-instance">§ 2.4.4 Find the next word bounded instance</a> of <em>prefix</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale">current
+of <a href="#next-word-bounded-instance">§ 2.4.5 Find the next word bounded instance</a> of <em>prefix</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale">current
 locale</a>.</p>
           <li data-md>
            <p>If <em>search position</em> is null, then break.</p>
@@ -1930,7 +2006,7 @@ locale</a>.</p>
            <p>If <em>search position</em> is at the end of <em>text</em>, then:</p>
            <ol>
             <li data-md>
-             <p>Perform <a href="#advance-walker-to-text">§ 2.4.3 Advance a TreeWalker to the next text node</a> on <em>walker</em>.</p>
+             <p>Perform <a href="#advance-walker-to-text">§ 2.4.4 Advance a TreeWalker to the next text node</a> on <em>walker</em>.</p>
             <li data-md>
              <p>If <em>walker.currentNode</em> is null, then return null.</p>
             <li data-md>
@@ -1941,11 +2017,11 @@ locale</a>.</p>
              <p><a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">Skip ASCII whitespace</a> on <em>search position</em>.</p>
            </ol>
           <li data-md>
-           <p>If the result of <a href="#next-word-bounded-instance">§ 2.4.4 Find the next word bounded instance</a> of <em>query</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale①">current locale</a> does not start at <em>search
+           <p>If the result of <a href="#next-word-bounded-instance">§ 2.4.5 Find the next word bounded instance</a> of <em>query</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale①">current locale</a> does not start at <em>search
 position</em>, then continue.</p>
          </ol>
         <li data-md>
-         <p>Advance <em>search position</em> to the position after the result of <a href="#next-word-bounded-instance">§ 2.4.4 Find the next word bounded instance</a> of <em>query</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale②">current locale</a>.</p>
+         <p>Advance <em>search position</em> to the position after the result of <a href="#next-word-bounded-instance">§ 2.4.5 Find the next word bounded instance</a> of <em>query</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale②">current locale</a>.</p>
          <div class="note" role="note"> If a prefix was specified, the search position is at the beginning
 of <em>query</em> and this will advance it to the end of the query
 to search for a potential suffix. Otherwise, this will find the next
@@ -1965,7 +2041,7 @@ match position</em>.</p>
           <li data-md>
            <p>Let <em>suffix_walker</em> be a <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> that is a copy of <em>walker</em>.</p>
           <li data-md>
-           <p>Perform <a href="#advance-walker-to-text">§ 2.4.3 Advance a TreeWalker to the next text node</a> on <em>suffix_walker</em>.</p>
+           <p>Perform <a href="#advance-walker-to-text">§ 2.4.4 Advance a TreeWalker to the next text node</a> on <em>suffix_walker</em>.</p>
           <li data-md>
            <p>If <em>suffix_walker.currentNode</em> is null, then return null.</p>
           <li data-md>
@@ -1976,17 +2052,17 @@ match position</em>.</p>
            <p><a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">Skip ASCII whitespace</a> on <em>search position</em>.</p>
          </ol>
         <li data-md>
-         <p>If the result of <a href="#next-word-bounded-instance">§ 2.4.4 Find the next word bounded instance</a> of <em>suffix</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale③">current
+         <p>If the result of <a href="#next-word-bounded-instance">§ 2.4.5 Find the next word bounded instance</a> of <em>suffix</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale③">current
 locale</a> starts at <em>search position</em>, then return <em>potential match position</em>.</p>
        </ol>
       <li data-md>
-       <p>Perform <a href="#advance-walker-to-text">§ 2.4.3 Advance a TreeWalker to the next text node</a> on <em>walker</em>.</p>
+       <p>Perform <a href="#advance-walker-to-text">§ 2.4.4 Advance a TreeWalker to the next text node</a> on <em>walker</em>.</p>
      </ol>
     <li data-md>
      <p>Return null.</p>
    </ol>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="current-locale">current locale</dfn> is the <a href="https://html.spec.whatwg.org/multipage/dom.html#language">language</a> of the <em>currentNode</em>.</p>
-   <h4 class="heading settled" data-level="2.4.3" id="advance-walker-to-text"><span class="secno">2.4.3. </span><span class="content">Advance a TreeWalker to the next text node</span><a class="self-link" href="#advance-walker-to-text"></a></h4>
+   <h4 class="heading settled" data-level="2.4.4" id="advance-walker-to-text"><span class="secno">2.4.4. </span><span class="content">Advance a TreeWalker to the next text node</span><a class="self-link" href="#advance-walker-to-text"></a></h4>
    <div class="note" role="note"> The input <em>walker</em> is a <a href="https://dom.spec.whatwg.org/#treewalker">TreeWalker</a> reference, not a
 copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
    <ol>
@@ -1997,7 +2073,7 @@ copy, i.e. any modifications are performed on the caller’s instance of <em>wal
        <p>Advance the current node by calling <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode"> walker.nextNode()</a></p>
      </ol>
    </ol>
-   <h4 class="heading settled" data-level="2.4.4" id="next-word-bounded-instance"><span class="secno">2.4.4. </span><span class="content">Find the next word bounded instance</span><a class="self-link" href="#next-word-bounded-instance"></a></h4>
+   <h4 class="heading settled" data-level="2.4.5" id="next-word-bounded-instance"><span class="secno">2.4.5. </span><span class="content">Find the next word bounded instance</span><a class="self-link" href="#next-word-bounded-instance"></a></h4>
    <div class="note" role="note"> This algorithm has input <em>query, text, start position,</em> and <em>locale</em> and returns a Range that specifies the word bounded text
 instance if it is found. </div>
    <div class="note" role="note"> See <a href="https://github.com/tc39/proposal-intl-segmenter">Intl.Segmenter</a>,
@@ -2310,7 +2386,7 @@ manipulations
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#current-locale">current locale</a><span>, in §2.4.2</span>
+   <li><a href="#current-locale">current locale</a><span>, in §2.4.3</span>
    <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §2.6</span>
    <li><a href="#fragment-directive">fragment directive</a><span>, in §2.2.1</span>
    <li>
@@ -2322,6 +2398,8 @@ manipulations
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §2.2.1</span>
    <li><a href="#location">Location</a><span>, in §2.6</span>
    <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §2.2.2</span>
+   <li><a href="#scroll-a-domrect-into-view">scroll a DOMRect into view</a><span>, in §2.4.1</span>
+   <li><a href="#scroll-a-range-into-view">scroll a Range into view</a><span>, in §2.4.1</span>
    <li><a href="#textdirective">TextDirective</a><span>, in §2.2.2</span>
    <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §2.2.2</span>
    <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §2.2.2</span>
@@ -2423,10 +2501,22 @@ manipulations
     <li><a href="#ref-for-percentencodedchar">2.2.2. Fragment directive grammar</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="scroll-a-domrect-into-view">
+   <b><a href="#scroll-a-domrect-into-view">#scroll-a-domrect-into-view</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-scroll-a-domrect-into-view">2.4.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-a-domrect-into-view①">(2)</a> <a href="#ref-for-scroll-a-domrect-into-view②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="scroll-a-range-into-view">
+   <b><a href="#scroll-a-range-into-view">#scroll-a-range-into-view</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-scroll-a-range-into-view">2.4. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="current-locale">
    <b><a href="#current-locale">#current-locale</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-locale">2.4.2. Find an exact match with context</a> <a href="#ref-for-current-locale①">(2)</a> <a href="#ref-for-current-locale②">(3)</a> <a href="#ref-for-current-locale③">(4)</a>
+    <li><a href="#ref-for-current-locale">2.4.3. Find an exact match with context</a> <a href="#ref-for-current-locale①">(2)</a> <a href="#ref-for-current-locale②">(3)</a> <a href="#ref-for-current-locale③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragmentdirective①">

--- a/index.html
+++ b/index.html
@@ -1815,7 +1815,7 @@ fragment</a> algorithm with the following:</p>
        <ol>
         <li data-md>
          <p><a data-link-type="dfn" href="#scroll-a-range-into-view" id="ref-for-scroll-a-range-into-view">Scroll range into view</a>, with
-containingElement <em>target</em>, <em>behavior</em> set to "auto", <em>block</em> set to "start", and <em>inline</em> set to "nearest".</p>
+containingElement <em>target</em>, <em>behavior</em> set to "auto", <em>block</em> set to "center", and <em>inline</em> set to "nearest".</p>
        </ol>
       <li data-md>
        <p>Otherwise:</p>


### PR DESCRIPTION
This patch specifies how a Range is used as the indicated part of the document. It refactors the "scroll rect into view" part of the CSSOM's scroll element into view algorithm so that it can be reused in an algorithm scrolling a Range into view. _The indicated part of the document_ can now be specified as a Range in addition to an Element, where the element becomes the Document's target element and the Range is used for the scroll into view position.

Fixes #66 