### PR TITLE
[Spec] Fix up references to other specs.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -139,8 +139,7 @@ translation-hints or enabling accessibility features.
 
 ### Parsing the fragment directive ### {#parsing-the-fragment-directive}
 
-To the definition of
-<a href="https://dom.spec.whatwg.org/#concept-document">Document</a>, add:
+To the definition of [=Document=], add:
 
 <em>
 Each document has an associated <dfn>fragment directive</dfn> which is either
@@ -164,20 +163,20 @@ three consecutive code points U+003A (:), U+007E (~), U+003A (:).
 Amend the
 <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">
 create and initialize a Document object</a> steps to parse and remove the
-[=fragment directive=] from the Document's [[DOM#concept-document-url|URL]].
+[=fragment directive=] from the Document's [=Document/URL=].
 
 Replace steps 7 and 8 of this algorithm with:
 
 7. Let <em>url</em> be null
 8. If <em>request</em> is non-null, then set <em>document</em>'s
-    [[DOM#concept-document-url|URL]] to <em>request</em>'s
-    [[FETCH#concept-request-current-url|current URL]].
+    [=Document/URL=] to <em>request</em>'s
+    [=request/current URL=].
 9. Otherwise, set <em>url</em> to <em>response</em>'s
-    [[FETCH#concept-response-url|URL]].
+    [=response/URL=].
 10. Let <em>raw fragment</em> be equal to <em>url</em>'s
-    [[URL#concept-url-fragment|fragment]].
+    [=url/fragment=].
 11. Let <em>fragment directive position</em> be a
-    [[INFRA#string-position-variable|position variable]] that points to the
+    [=string/position variable=] that points to the
     beginning of <em>raw fragment</em>.
 12. While the string starting at position <em>fragment directive position</em>
     does not start with the [=fragment directive delimiter=] and <em>fragment
@@ -191,12 +190,12 @@ Replace steps 7 and 8 of this algorithm with:
         directive delimiter=].
     3. Let <em>fragment directive</em> be the substring of <em>raw fragment</em>
         starting at <em>fragment directive position</em>.
-    4. Set <em>url</em>'s [[URL#concept-url-fragment|fragment]] to
+    4. Set <em>url</em>'s [=url/fragment=] to
         <em>fragment</em>.
     5. Set <em>document</em>'s [=fragment directive=] to <em>fragment
         directive</em>. (Note: this is stored on the document but not
         web-exposed)
-14. Set <em>document</em>'s [[DOM#concept-document-url|URL]] to be <em>url</em>.
+14. Set <em>document</em>'s [=Document/URL=] to be <em>url</em>.
 
 <div class="note">
   These changes make a URL's fragment end at the [=fragment directive
@@ -254,7 +253,7 @@ enables specifying a piece of text on the page, that matches the production:
 
 <div class = "note">
 A [=ExplicitChar=] may be any
-<a href="https://url.spec.whatwg.org/#url-code-points">URL code point</a> that
+[=URL code point=] that
 is not explicitly used in the [=TextDirective=] syntax, that is "&", "-", and
 ",", which must be percent-encoded.
 </div>
@@ -383,19 +382,19 @@ asynchronous task to find and set the indicated part of the document.
 </div>
 
 1. If <em>is user triggered</em> is false, return false.
-2. If the <a href="https://html.spec.whatwg.org/#document">Document</a> of the
-   [[HTML#latest-entry|latest entry]] in <em>document</em>'s
-   [[HTML#browsing-context|browsing context]]'s
-   [[HTML#session-history|session history]] is equal to <em>document</em>,
-   return false.
-   <div class="note">
-     i.e. Forbidden on a same-document navigation.
-   </div>
+2. If the {{Document}} of the <a spec=HTML>latest entry</a> in
+    <em>document</em>'s [=browsing context=]'s
+    <a spec=HTML>session history</a> is equal to <em>document</em>,
+    return false.
+    <div class="note">
+      i.e. Forbidden on a same-document navigation.
+    </div>
 3. If <em>incumbentNavigationOrigin</em> is equal to the origin of
    <em>document</em> return true.
-4. If <em>document</em>'s <em>browsingContext</em> is a top level browsing context and its
-   [[HTML#tlbc-group|group]]'s [[HTML#browsing-context-set|browsing context set]]
-   has length 1 return true.
+4. If <em>document</em>'s <em>browsingContext</em> is a top level browsing
+   context and its
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>'s
+   <a spec=HTML>browsing context set</a> has length 1 return true.
    <div class="note">
      i.e. Only allow navigation from a cross-process element/script if the
      document is loaded in a noopener context. That is, a new top level
@@ -411,7 +410,7 @@ asynchronous task to find and set the indicated part of the document.
   allowed to invoke must be run during document navigation and creation and
   stored as a flag since it relies on the properties of the navigation while
   the invocation will occur as part of the
-  [[HTML#scroll-to-the-fragment-identifier|scroll to the fragment]] steps which
+  <a spec=HTML>scroll to the fragment</a> steps which
   can happen outside the context of a navigation.
 </div>
 
@@ -425,7 +424,7 @@ these steps after step 1:
    result of running [[#should-allow-text-fragment]] with <em>is user
    activated</em>, <em>incumbentNavigationOrigin</em>, and <em>document</em>.
 
-Amend the [[HTML#try-to-scroll-to-the-fragment|try to scroll to the fragment]]
+Amend the <a spec=HTML>try to scroll to the fragment</a>
 steps by replacing the steps of the task queued in step 2:
 
 1. If document has no parser, or its parser has stopped parsing, or the user
@@ -444,20 +443,18 @@ The text fragment specification proposes an amendment to
 [[html#scroll-to-fragid]]. In summary, if a [=text fragment directive=] is
 present and a match is found in the page, the text fragment takes precedent over
 the element fragment as the indicated part of the document. We amend the
-indicated part of the document to optionally include a [[DOM#range|Range]] that
+indicated part of the document to optionally include a {{Range}} that
 may be scrolled into view instead of the containing element.
 </div>
 
-Replace step 3.1 of the [[HTML#scroll-to-the-fragment-identifier|scroll to the
-fragment]] algorithm with the following:
+Replace step 3.1 of the <a spec=HTML>scroll to the fragment</a> algorithm with
+the following:
 3. Otherwise:
-    1. Let <em>target, range</em> be the [[DOM#element|Element]] and
-        [[DOM#range|Range]] that is
-        [[HTML#the-indicated-part-of-the-document|the indicated part of the
-        document]].
+    1. Let <em>target, range</em> be the {{Element}} and {{Range}} that is
+       <a spec=HTML>the indicated part of the document</a>.
 
-Replace step 3.3 of the [[HTML#scroll-to-the-fragment-identifier|scroll to the
-fragment]] algorithm with the following:
+Replace step 3.3 of the <a spec=HTML>scroll to the fragment</a> algorithm with
+the following:
 3. Otherwise:
     3. If <em>range</em> is non-null:
         1. If the UA supports scrolling of text fragments on navigation, invoke
@@ -465,77 +462,71 @@ fragment]] algorithm with the following:
             containingElement <em>target</em>, <em>behavior</em> set to "auto",
             <em>block</em> set to "center", and <em>inline</em> set to "nearest".
     4. Otherwise:
-        1. [[cssom-view#scroll-an-element-into-view|Scroll target into view]],
-            with <em>behavior</em> set to "auto", <em>block</em> set to "start",
-            and <em>inline</em> set to "nearest".
-            <div class="note">This otherwise case is the same as the current
-            step 3.3.</div>
+        1. <a spec=cssom-view lt="scroll an element into view">Scroll target
+            into view</a>, with <em>behavior</em> set to "auto", <em>block</em>
+            set to "start", and <em>inline</em> set to "nearest".
+            <div class="note">
+                This otherwise case is the same as the current step 3.3.
+            </div>
 
 
 Add the following steps to the beginning of the processing model for
-[[HTML#the-indicated-part-of-the-document|the indicated part of the document]]:
+<a spec=HTML>the indicated part of the document</a>:
 
 1. Let <em>fragment directive string</em> be the <em>document</em>'s [=fragment
     directive=].
 2. If <em>document</em>'s [[#allow-text-fragment-directive-flag]] is true then:
-    1. Let <em>ranges</em> be a [[INFRA#list|list]] that is the result of
+    1. Let <em>ranges</em> be a <a spec=infra>list</a> that is the result of
         [[#find-text-matches]] with <em>fragment directive string</em>.
     2. If <em>ranges</em> is non-empty, then:
         1. Let <em>range</em> be the first item of <em>ranges</em>.
             <div class="note">
-            The first [[DOM#range|Range]] in <em>ranges</em> is specifically
-            scrolled into view. This [[DOM#range|Range]], along with the
+            The first {{Range}} in <em>ranges</em> is specifically
+            scrolled into view. This {{Range}}, along with the
             remaining <em>ranges</em> should be visually indicated in a way that
             is not revealed to script, which is left as UA-defined behavior.
             </div>
         2. Let <em>node</em> be <em>range</em>'s
-            [[DOM#dom-range-commonancestorcontainer|commonAncestorContainer]].
-        3. While <em>node</em>'s [[DOM#dom-node-nodetype|nodeType]] is not
-            [[DOM#dom-node-element_node|ELEMENT_NODE]]:
+            {{Range/commonAncestorContainer}}.
+        3. While <em>node</em>'s {{Node/nodeType}} is not
+            {{Node/ELEMENT_NODE}}:
             1. Set <em>node</em> to <em>node</em>'s
-                [[DOM#dom-node-parentnode|parentNode]].
+                {{Node/parentNode}}.
         4. The indicated part of the document is <em>node</em> and
             <em>range</em>; return.
 
 ### Scroll a DOMRect into view ### {#scroll-rect-into-view}
 <div class="note">
   This section describes a refactoring of the CSSOMVIEW's
-  [[cssom-view#scroll-an-element-into-view|scroll an element into view]] algorithm 
+  <a spec=cssom-view>scroll an element into view</a> algorithm 
   to separate the steps for scrolling a DOMRect into view, so it can be used to
   scroll a Range into view.
 </div>
 
-Move the [[cssom-view#scroll-an-element-into-view|scroll an element into
-view]] algorithm's steps 3-14 into a new algorithm <dfn>scroll a DOMRect into
-view</dfn>, with input <a
-href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> <em>bounding
-box</em>, [[cssom-view#dictdef-scrollintoviewoptions|ScrollIntoViewOptions]]
-dictionary <em>options</em>, and [[DOM#element|Element]]
-<em>startingElement</em>. Also move the recursive behavior described at the top
-of the [[cssom-view#scroll-an-element-into-view|scroll an element into view]]
-algorithm to the [=scroll a DOMRect into view=] algorithm: "run these steps for
-each ancestor element or viewport <b>of <em>startingElement</em></b> that
-establishes a scrolling box <em>scrolling box</em>, in order of innermost to
-outermost scrolling box".
+Move the <a spec=cssom-view>scroll an element into view</a> algorithm's steps
+3-14 into a new algorithm <dfn>scroll a DOMRect into view</dfn>, with input
+{{DOMRect}} <em>bounding box</em>, {{ScrollIntoViewOptions}} dictionary
+<em>options</em>, and {{Element}} <em>startingElement</em>. Also move the
+recursive behavior described at the top of the <a spec=cssom-view>scroll an
+element into view</a> algorithm to the [=scroll a DOMRect into view=]
+algorithm: "run these steps for each ancestor element or viewport <b>of
+<em>startingElement</em></b> that establishes a scrolling box <em>scrolling
+box</em>, in order of innermost to outermost scrolling box".
+
 <div class="note">
-<em>bounding box</em> is renamed from <em>element bounding border box</em>.
+  <em>bounding box</em> is renamed from <em>element bounding border box</em>.
 </div>
 
-Replace steps 3-14 of the [[cssom-view#scroll-an-element-into-view|scroll an
-element into view]] algorithm with a call to [=scroll a DOMRect into view=]:
+Replace steps 3-14 of the <a spec=cssom-view>scroll an element into view</a>
+algorithm with a call to [=scroll a DOMRect into view=]:
 3. Perform [=scroll a DOMRect into view=] on <em>element bounding border
     box</em> with options <em>options</em> and startingElement <em>element</em>.
 
 Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
-[[DOM#range|Range]] <em>range</em>, [[DOM#element|Element]]
-<em>containingElement</em>, and a
-[[cssom-view#dictdef-scrollintoviewoptions|ScrollIntoViewOptions]] dictionary
-<em>options</em>:
-1. Let <em>bounding rect</em> be the <a
-    href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> that is
-    the return value of invoking
-    [[cssom-view#dom-range-getboundingclientrect|getBoundingClientRect()]]
-    on <em>range</em>.
+{{Range}} <em>range</em>, {{Element}} <em>containingElement</em>, and a
+{{ScrollIntoViewOptions}} dictionary <em>options</em>:
+1. Let <em>bounding rect</em> be the {{DOMRect}} that is the return value of
+   invoking {{Range/getBoundingClientRect()}} on <em>range</em>.
 2. Perform [=scroll a DOMRect into view=] on <em>bounding rect</em> with
     <em>options</em> and startingElement <em>containingElement</em>.
 
@@ -543,29 +534,29 @@ Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
 
 <div class="note">
 This algorithm has input <em>fragment directive input</em>, that is the raw
-fragment directive string, and returns a [[INFRA#list|list]] of
-[[DOM#range|Range]]s that are to be visually indicated, and the first should be
+fragment directive <a spec=infra>string</a>, and returns a <a spec=infra>list</a> of
+{{Range}}s that are to be visually indicated, and the first should be
 scrolled into view.
 </div>
 
 1. If <em>fragment directive input</em> does not match the [=FragmentDirective=]
-    production, then return an empty [[INFRA#list|list]].
-2. Let <em>directives</em> be a [[INFRA#list|list]] of strings that is the
-    result of [[INFRA#strictly-split|splitting]] <em>fragment directive
-    input</em> on "&".
-3. Let <em>ranges</em> be a [[INFRA#list|list]] of [[DOM#range|Range]]s that is
+    production, then return an empty <a spec=infra>list</a>.
+2. Let <em>directives</em> be a <a spec=infra>list</a> of <a spec=infra>string</a>s
+    that is the result of [=strictly split a string|strictly splitting the string=]
+    <em>fragment directive input</em> on "&".
+3. Let <em>ranges</em> be a <a spec=infra>list</a> of {{Range}}s that is
     initially empty.
-4. For each string <em>directive</em> in <em>directives</em>:
+4. For each <a spec=infra>string</a> <em>directive</em> in <em>directives</em>:
     1. If <em>directive</em> does not match the production [=TextDirective=],
         then continue.
     2. If the result of [[#find-a-target-text]] on <em>directive</em> is
-        non-null, then [[INFRA#list-append|append]] it to <em>ranges</em>.
+        non-null, then <a spec=infra for=list>append</a> it to <em>ranges</em>.
 5. Return <em>ranges</em>.
 
 ### Find a target text ### {#find-a-target-text}
 
-To find the target text for a given string <em>text directive input</em>,
-the user agent must run these steps:
+To find the target text for a given <a spec=infra>string</a> <em>text
+directive input</em>, the user agent must run these steps:
 1. If <em>text directive input</em> does not begin with the string "text=",
     then return null.
 2. Let <em>raw target text</em> be the substring of <em>text directive
@@ -575,51 +566,50 @@ the user agent must run these steps:
     but not including, the "text=" prefix.
     </div>
 3. If <em>raw target text</em> is the empty string, return null.
-4. Let <em>tokens</em> be a [[INFRA#list|list]] of strings that is the result of
-    [[INFRA#split-on-commas|splitting a string on commas]] of <em>raw target
-    text</em>.
+4. Let <em>tokens</em> be a <a spec=infra>list</a> of
+    <a spec="infra">string</a>s that is the result of
+    <a spec=infra lt="split on commas">splitting <em>raw target text</em> on
+    commas</a>.
 5. Let <em>prefix</em> and <em>suffix</em> and <em>textEnd</em> be the empty
     string.
     <div class="note">
-    prefix, suffix, and textEnd are the optional parameters of the text
-    directive.
+      prefix, suffix, and textEnd are the optional parameters of the text
+      directive.
     </div>
 6. Let <em>potential prefix</em> be the first item of <em>tokens</em>.
 7. If the last character of <em>potential prefix</em> is U+002D (-), then:
     1. Set <em>prefix</em> to the result of removing the last character from
         <em>potential prefix</em>.
-    2. [[INFRA#list-remove|Remove]] the first item of the list <em>tokens</em>.
-8. Let <em>potential suffix</em> be the last item of <em>tokens</em>.
+    2. <a spec=infra for=list>Remove</a> the first item of <em>tokens</em>.
+8. Let <em>potential suffix</em> be the last item from <em>tokens</em>.
 9. If the first character of <em>potential suffix</em> is U+002D (-), then:
     1. Set <em>suffix</em> to the result of removing the first character from
         <em>potential suffix</em>.
-    2. [[INFRA#list-remove|Remove]] the last item of the list <em>tokens</em>.
-10. Assert: <em>tokens</em> has [[INFRA#list-size|size]] 1 or <em>tokens</em>
-    has [[INFRA#list-size|size]] 2.
+    2. <a spec=infra for=list>Remove</a> the last item from <em>tokens</em>.
+10. Assert: <em>tokens</em> has <a spec=infra for=list>size</a> 1 or <em>tokens</em>
+    has <a spec=infra for=list>size</a> 2.
     <div class="note">
     Once the prefix and suffix are removed from tokens, tokens may either
     contain one item (textStart) or two items (textStart and textEnd).
     </div>
 11. Let <em>textStart</em> be the first item of <em>tokens</em>.
-12. If <em>tokens</em> has [[INFRA#list-size|size]] 2, then let <em>textEnd</em>
+12. If <em>tokens</em> has <a spec=infra for=list>size</a> 2, then let <em>textEnd</em>
     be the last item of <em>tokens</em>.
     <div class="note">
     The strings prefix, textStart, textEnd, and suffix now contain the
     text directive parameters as defined in [[#syntax]].
     </div>
-13. Let <em>walker</em> be a
-    [[DOM#treewalker|TreeWalker]] equal to
-    [[DOM#dom-document-createtreewalker|Document.createTreeWalker()]].
-14. Let <em>position</em> be a [[INFRA#string-position-variable|position
-    variable]] that indicates a text offset in
-    <em>walker.currentNode.innerText</em>.
+13. Let <em>walker</em> be a {{TreeWalker}} equal to
+    {{Document/createTreeWalker()}}.
+14. Let <em>position</em> be a <a spec=infra for=string>position variable</a>
+    that indicates a text offset in <em>walker.currentNode.innerText</em>.
 15. If textEnd is the empty string, then:
     1. Let <em>match position</em> be the result of [[#find-match-with-context]]
         with input walker <em>walker</em>, search position <em>position</em>,
         prefix <em>prefix</em>, query <em>textStart</em>, and suffix
         <em>suffix</em>.
     2. If <em>match position</em> is null, then return null.
-    3. Let <em>match</em> be a Range in <em>walker.currentNode</em> with
+    3. Let <em>match</em> be a {{Range}} in <em>walker.currentNode</em> with
         position <em>match position</em> and length equal to the length of
         <em>textStart</em>.
     4. Return <em>match</em>.
@@ -634,7 +624,7 @@ the user agent must run these steps:
     <em>suffix</em>.
 19. If <em>end position</em> is null, then return null.
 20. Advance <em>end position</em> by the length of <em>textEnd</em>.
-21. Let <em>match</em> be a Range in <em>walker.currentNode</em> with start 
+21. Let <em>match</em> be a {{Range}} in <em>walker.currentNode</em> with start 
     position <em>potential start position</em> and length equal to <em>end
     position - start position</em>.
 22. Return <em>match</em>.
@@ -645,9 +635,8 @@ This algorithm has input <em>walker, search position, prefix, query,</em> and
 <em>suffix</em> and returns a text position that is the start of the match.
 </div>
 <div class="note">
-The input <em>walker</em> is a [[DOM#treewalker|TreeWalker]] reference, not a
-copy, i.e. any modifications are performed on the caller's instance of
-<em>walker</em>.
+  The input <em>walker</em> is a {{TreeWalker}} reference, not a copy, i.e. any
+  modifications are performed on the caller's instance of <em>walker</em>.
 </div>
 
 1. While <em>walker.currentNode</em> is not null:
@@ -661,16 +650,16 @@ copy, i.e. any modifications are performed on the caller's instance of
                 <em>text</em> from <em>search position</em> with [=current
                 locale=].
             2. If <em>search position</em> is null, then break.
-            3. [[INFRA#skip-ascii-whitespace|Skip ASCII whitespace]] on
-                <em>search position</em>.
+            3. <a spec=infra>Skip ASCII whitespace</a> on <em>search
+                position</em>.
             4. If <em>search position</em> is at the end of <em>text</em>, then:
                 1. Perform [[#advance-walker-to-text]] on <em>walker</em>.
                 2. If <em>walker.currentNode</em> is null, then return null.
                 3. Set <em>text</em> to <em>walker.currentNode.innerText</em>.
                 4. Set <em>search position</em> to the beginning of
                     <em>text</em>.
-                5. [[INFRA#skip-ascii-whitespace|Skip ASCII whitespace]] on
-                    <em>search position</em>.
+                5. <a spec=infra>Skip ASCII whitespace</a> on <em>search
+                    position</em>.
             5. If the result of [[#next-word-bounded-instance]] of
                 <em>query</em> in <em>text</em> from <em>search position</em> 
                 with [=current locale=] does not start at <em>search
@@ -679,29 +668,28 @@ copy, i.e. any modifications are performed on the caller's instance of
             [[#next-word-bounded-instance]] of <em>query</em> in <em>text</em>
             from <em>search position</em> with [=current locale=].
             <div class="note">
-            If a prefix was specified, the search position is at the beginning
-            of <em>query</em> and this will advance it to the end of the query
-            to search for a potential suffix. Otherwise, this will find the next
-            instance of query.
+              If a prefix was specified, the search position is at the
+              beginning of <em>query</em> and this will advance it to the end
+              of the query to search for a potential suffix. Otherwise, this
+              will find the next instance of query.
             </div>
         3. If <em>search position</em> is null, then break.
         4. Let <em>potential match position</em> be a
-            [[INFRA#string-position-variable|position variable]] equal to
-            <em>search position</em> minus the length of <em>query</em>.
+            <a spec=infra for=string>position variable</a> equal to <em>search
+            position</em> minus the length of <em>query</em>.
         5. If <em>suffix</em> is the empty string, then return <em>potential
             match position</em>.
-        6. [[INFRA#skip-ascii-whitespace|Skip ASCII whitespace]] on
-            <em>search position</em>.
+        6. <a spec=infra>Skip ASCII whitespace</a> on <em>search position</em>.
         7. If <em>search position</em> is at the end of <em>text</em>, then:
-            1. Let <em>suffix_walker</em> be a [[DOM#treewalker|TreeWalker]]
-                that is a copy of <em>walker</em>.
+            1. Let <em>suffix_walker</em> be a {{TreeWalker}} that is a copy of
+                <em>walker</em>.
             2. Perform [[#advance-walker-to-text]] on <em>suffix_walker</em>.
             3. If <em>suffix_walker.currentNode</em> is null, then return null.
             4. Set <em>text</em> to
                 <em>suffix_walker.currentNode.innerText</em>.
             5. Set <em>search position</em> to the beginning of <em>text</em>.
-            6. [[INFRA#skip-ascii-whitespace|Skip ASCII whitespace]] on
-                <em>search position</em>.
+            6. <a spec=infra>Skip ASCII whitespace</a> on <em>search
+                position</em>.
         8. If the result of [[#next-word-bounded-instance]] of <em>suffix</em>
             in <em>text</em> from <em>search position</em> with [=current
             locale=] starts at <em>search position</em>, then return
@@ -709,22 +697,19 @@ copy, i.e. any modifications are performed on the caller's instance of
     4. Perform [[#advance-walker-to-text]] on <em>walker</em>.
 2. Return null.
 
-The <dfn>current locale</dfn> is the
-<a href="https://html.spec.whatwg.org/multipage/dom.html#language">language</a>
-of the <em>currentNode</em>.
+The <dfn>current locale</dfn> is the <a spec=html>language</a> of the
+<em>currentNode</em>.
 
 ### Advance a TreeWalker to the next text node ### {#advance-walker-to-text}
 <div class="note">
-The input <em>walker</em> is a [[DOM#treewalker|TreeWalker]] reference, not a
-copy, i.e. any modifications are performed on the caller's instance of
-<em>walker</em>.
+  The input <em>walker</em> is a {{TreeWalker}} reference, not a
+  copy, i.e. any modifications are performed on the caller's instance of
+  <em>walker</em>.
 </div>
 
 1. While the input <em>walker.currentNode</em> is not null and 
     <em>walker.currentNode</em> is not a text node:
-    1. Advance the current node by calling
-        <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode">
-        walker.nextNode()</a>
+    1. Advance the current node by calling {{TreeWalker/nextNode()|walker.nextNode()}}.
 
 ### Find the next word bounded instance ### {#next-word-bounded-instance}
 <div class="note">
@@ -778,9 +763,8 @@ API for word boundary matching.
 ## Indicating The Text Match ## {#indicating-the-text-match}
 
 The UA may choose to scroll the text fragment into view as part of the <a
-href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">
-Try To Scroll To The Fragment</a> steps or by some other mechanism; however, it
-is not required to scroll the match into view.
+spec=HTML>try to scroll to the fragment</a> steps or by some other mechanism;
+however, it is not required to scroll the match into view.
 
 The UA should visually indicate the matched text in some way such that the user
 is made aware of the text match, such as with a high-contrast highlight.
@@ -807,9 +791,8 @@ interface FragmentDirective {
 };
 </pre>
 
-We amend
-<a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface">
-The Location Interface</a> to include a <code>fragmentDirective</code> property:
+We amend the {{Location}} interface to include a <code>fragmentDirective</code>
+property:
 
 <pre class='idl'>
 interface Location {

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 8bc2fccb49a45a0af18c5e75ce18049d75f824b6" name="generator">
+  <meta content="Bikeshed version ae6def1cbca03b321b2ad730ac2f51eeba21ed81" name="generator">
   <link href="wicg.github.io/ScrollToTextFragment/index.html" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1470,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-01-30">30 January 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-18">18 February 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1568,6 +1568,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
      </ol>
     <li>
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
@@ -1670,7 +1671,7 @@ author script so that future UA instructions can be added without fear of
 introducing breaking changes to existing content. Potential examples could be:
 translation-hints or enabling accessibility features.</p>
    <h4 class="heading settled" data-level="2.3.1" id="parsing-the-fragment-directive"><span class="secno">2.3.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
-   <p>To the definition of <a href="https://dom.spec.whatwg.org/#concept-document">Document</a>, add:</p>
+   <p>To the definition of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>, add:</p>
    <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is either
 null or an ASCII string holding data used by the UA to process the resource. It
 is initially null. </em></p>
@@ -1680,19 +1681,19 @@ three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
   always appear after a U+0023 (#) code point in a URL. </div>
    <div class="example" id="example-aa58e32d"><a class="self-link" href="#example-aa58e32d"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a> to a URL like https://example.com, a fragment
   must first be appended to the URL: https://example.com#:~:text=foo. </div>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to parse and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> from the Document’s <span spec-section="#concept-document-url">URL</span>.</p>
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to parse and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> from the Document’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url">URL</a>.</p>
    <p>Replace steps 7 and 8 of this algorithm with:</p>
    <ol start="7">
     <li data-md>
      <p>Let <em>url</em> be null</p>
     <li data-md>
-     <p>If <em>request</em> is non-null, then set <em>document</em>’s <span spec-section="#concept-document-url">URL</span> to <em>request</em>’s <span spec-section="#concept-request-current-url">current URL</span>.</p>
+     <p>If <em>request</em> is non-null, then set <em>document</em>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url①">URL</a> to <em>request</em>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a>.</p>
     <li data-md>
-     <p>Otherwise, set <em>url</em> to <em>response</em>’s <span spec-section="#concept-response-url">URL</span>.</p>
+     <p>Otherwise, set <em>url</em> to <em>response</em>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">URL</a>.</p>
     <li data-md>
-     <p>Let <em>raw fragment</em> be equal to <em>url</em>’s <span spec-section="#concept-url-fragment">fragment</span>.</p>
+     <p>Let <em>raw fragment</em> be equal to <em>url</em>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment">fragment</a>.</p>
     <li data-md>
-     <p>Let <em>fragment directive position</em> be a <span spec-section="#string-position-variable">position variable</span> that points to the
+     <p>Let <em>fragment directive position</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable">position variable</a> that points to the
 beginning of <em>raw fragment</em>.</p>
     <li data-md>
      <p>While the string starting at position <em>fragment directive position</em> does not start with the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive delimiter</a> and <em>fragment
@@ -1712,14 +1713,14 @@ directive delimiter</a>.</p>
       <li data-md>
        <p>Let <em>fragment directive</em> be the substring of <em>raw fragment</em> starting at <em>fragment directive position</em>.</p>
       <li data-md>
-       <p>Set <em>url</em>’s <span spec-section="#concept-url-fragment">fragment</span> to <em>fragment</em>.</p>
+       <p>Set <em>url</em>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment①">fragment</a> to <em>fragment</em>.</p>
       <li data-md>
        <p>Set <em>document</em>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> to <em>fragment
 directive</em>. (Note: this is stored on the document but not
 web-exposed)</p>
      </ol>
     <li data-md>
-     <p>Set <em>document</em>’s <span spec-section="#concept-document-url">URL</span> to be <em>url</em>.</p>
+     <p>Set <em>document</em>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url②">URL</a> to be <em>url</em>.</p>
    </ol>
    <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive
   delimiter</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> includes all characters that follow,
@@ -1763,7 +1764,7 @@ enables specifying a piece of text on the page, that matches the production:</p>
 "(" | ")" | "*" | "+" | "." | "/" | ":" | ";" | "=" | "?" | "@" | "_" | "~"</code>
     <code> </code>
     <p></p>
-    <div class="note" role="note"> A <a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar①">ExplicitChar</a> may be any <a href="https://url.spec.whatwg.org/#url-code-points">URL code point</a> that
+    <div class="note" role="note"> A <a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar①">ExplicitChar</a> may be any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points">URL code point</a> that
 is not explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a> syntax, that is "&amp;", "-", and
 ",", which must be percent-encoded. </div>
      <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar">PercentEncodedChar</dfn> ::=</dt><dd>"%" [a-zA-Z0-9]+</dd></code> 
@@ -1851,13 +1852,14 @@ asynchronous task to find and set the indicated part of the document.</p>
     <li data-md>
      <p>If <em>is user triggered</em> is false, return false.</p>
     <li data-md>
-     <p>If the <a href="https://html.spec.whatwg.org/#document">Document</a> of the <span spec-section="#latest-entry">latest entry</span> in <em>document</em>’s <span spec-section="#browsing-context">browsing context</span>'s <span spec-section="#session-history">session history</span> is equal to <em>document</em>,
-   return false.</p>
+     <p>If the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#latest-entry" id="ref-for-latest-entry">latest entry</a> in <em>document</em>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context" id="ref-for-browsing-context">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#session-history" id="ref-for-session-history">session history</a> is equal to <em>document</em>,
+return false.</p>
      <div class="note" role="note"> i.e. Forbidden on a same-document navigation. </div>
     <li data-md>
      <p>If <em>incumbentNavigationOrigin</em> is equal to the origin of <em>document</em> return true.</p>
     <li data-md>
-     <p>If <em>document</em>’s <em>browsingContext</em> is a top level browsing context and its <span spec-section="#tlbc-group">group</span>'s <span spec-section="#browsing-context-set">browsing context set</span> has length 1 return true.</p>
+     <p>If <em>document</em>’s <em>browsingContext</em> is a top level browsing
+   context and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1 return true.</p>
      <div class="note" role="note"> i.e. Only allow navigation from a cross-process element/script if the
  document is loaded in a noopener context. That is, a new top level
  browsing context group to which the navigator does not have script access
@@ -1869,7 +1871,7 @@ asynchronous task to find and set the indicated part of the document.</p>
    <div class="note" role="note"> The algorithm to determine whether or not a text fragment directive should be
   allowed to invoke must be run during document navigation and creation and
   stored as a flag since it relies on the properties of the navigation while
-  the invocation will occur as part of the <span spec-section="#scroll-to-the-fragment-identifier">scroll to the fragment</span> steps which
+  the invocation will occur as part of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier">scroll to the fragment</a> steps which
   can happen outside the context of a navigation. </div>
    <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-html">page load processing model for HTML files</a> to insert
 these steps after step 1:</p>
@@ -1882,7 +1884,7 @@ these steps after step 1:</p>
    result of running <a href="#should-allow-text-fragment">§ 2.4.4 Should Allow Text Fragment</a> with <em>is user
    activated</em>, <em>incumbentNavigationOrigin</em>, and <em>document</em>.</p>
    </ol>
-   <p>Amend the <span spec-section="#try-to-scroll-to-the-fragment">try to scroll to the fragment</span> steps by replacing the steps of the task queued in step 2:</p>
+   <p>Amend the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment">try to scroll to the fragment</a> steps by replacing the steps of the task queued in step 2:</p>
    <ol>
     <li data-md>
      <p>If document has no parser, or its parser has stopped parsing, or the user
@@ -1899,21 +1901,20 @@ these steps after step 1:</p>
    <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.8.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑦">text fragment directive</a> is
 present and a match is found in the page, the text fragment takes precedent over
 the element fragment as the indicated part of the document. We amend the
-indicated part of the document to optionally include a <span spec-section="#range">Range</span> that
+indicated part of the document to optionally include a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range">Range</a></code> that
 may be scrolled into view instead of the containing element. </div>
-   <p>Replace step 3.1 of the <span spec-section="#scroll-to-the-fragment-identifier">scroll to the
-fragment</span> algorithm with the following:</p>
+   <p>Replace step 3.1 of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier①">scroll to the fragment</a> algorithm with
+the following:</p>
    <ol start="3">
     <li data-md>
      <p>Otherwise:</p>
      <ol>
       <li data-md>
-       <p>Let <em>target, range</em> be the <span spec-section="#element">Element</span> and <span spec-section="#range">Range</span> that is <span spec-section="#the-indicated-part-of-the-document">the indicated part of the
-document</span>.</p>
+       <p>Let <em>target, range</em> be the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①">Range</a></code> that is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document" id="ref-for-the-indicated-part-of-the-document">the indicated part of the document</a>.</p>
      </ol>
    </ol>
-   <p>Replace step 3.3 of the <span spec-section="#scroll-to-the-fragment-identifier">scroll to the
-fragment</span> algorithm with the following:</p>
+   <p>Replace step 3.3 of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier②">scroll to the fragment</a> algorithm with
+the following:</p>
    <ol start="3">
     <li data-md>
      <p>Otherwise:</p>
@@ -1929,15 +1930,13 @@ containingElement <em>target</em>, <em>behavior</em> set to "auto", <em>block</e
        <p>Otherwise:</p>
        <ol>
         <li data-md>
-         <p><span spec-section="#scroll-an-element-into-view">Scroll target into view</span>,
-with <em>behavior</em> set to "auto", <em>block</em> set to "start",
-and <em>inline</em> set to "nearest".</p>
-         <div class="note" role="note">This otherwise case is the same as the current
-step 3.3.</div>
+         <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view">Scroll target
+into view</a>, with <em>behavior</em> set to "auto", <em>block</em> set to "start", and <em>inline</em> set to "nearest".</p>
+         <div class="note" role="note"> This otherwise case is the same as the current step 3.3. </div>
        </ol>
      </ol>
    </ol>
-   <p>Add the following steps to the beginning of the processing model for <span spec-section="#the-indicated-part-of-the-document">the indicated part of the document</span>:</p>
+   <p>Add the following steps to the beginning of the processing model for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document" id="ref-for-the-indicated-part-of-the-document①">the indicated part of the document</a>:</p>
    <ol>
     <li data-md>
      <p>Let <em>fragment directive string</em> be the <em>document</em>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment
@@ -1946,23 +1945,23 @@ directive</a>.</p>
      <p>If <em>document</em>’s <a href="#allow-text-fragment-directive-flag">§ 2.4.5 allowTextFragmentDirective flag</a> is true then:</p>
      <ol>
       <li data-md>
-       <p>Let <em>ranges</em> be a <span spec-section="#list">list</span> that is the result of <a href="#find-text-matches">§ 2.5.2 Find text matches</a> with <em>fragment directive string</em>.</p>
+       <p>Let <em>ranges</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> that is the result of <a href="#find-text-matches">§ 2.5.2 Find text matches</a> with <em>fragment directive string</em>.</p>
       <li data-md>
        <p>If <em>ranges</em> is non-empty, then:</p>
        <ol>
         <li data-md>
          <p>Let <em>range</em> be the first item of <em>ranges</em>.</p>
-         <div class="note" role="note"> The first <span spec-section="#range">Range</span> in <em>ranges</em> is specifically
-scrolled into view. This <span spec-section="#range">Range</span>, along with the
+         <div class="note" role="note"> The first <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range②">Range</a></code> in <em>ranges</em> is specifically
+scrolled into view. This <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range③">Range</a></code>, along with the
 remaining <em>ranges</em> should be visually indicated in a way that
 is not revealed to script, which is left as UA-defined behavior. </div>
         <li data-md>
-         <p>Let <em>node</em> be <em>range</em>’s <span spec-section="#dom-range-commonancestorcontainer">commonAncestorContainer</span>.</p>
+         <p>Let <em>node</em> be <em>range</em>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-range-commonancestorcontainer" id="ref-for-dom-range-commonancestorcontainer">commonAncestorContainer</a></code>.</p>
         <li data-md>
-         <p>While <em>node</em>’s <span spec-section="#dom-node-nodetype">nodeType</span> is not <span spec-section="#dom-node-element_node">ELEMENT_NODE</span>:</p>
+         <p>While <em>node</em>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-nodetype" id="ref-for-dom-node-nodetype">nodeType</a></code> is not <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-element_node" id="ref-for-dom-node-element_node">ELEMENT_NODE</a></code>:</p>
          <ol>
           <li data-md>
-           <p>Set <em>node</em> to <em>node</em>’s <span spec-section="#dom-node-parentnode">parentNode</span>.</p>
+           <p>Set <em>node</em> to <em>node</em>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-parentnode" id="ref-for-dom-node-parentnode">parentNode</a></code>.</p>
          </ol>
         <li data-md>
          <p>The indicated part of the document is <em>node</em> and <em>range</em>; return.</p>
@@ -1970,63 +1969,58 @@ is not revealed to script, which is left as UA-defined behavior. </div>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="2.5.1" id="scroll-rect-into-view"><span class="secno">2.5.1. </span><span class="content">Scroll a DOMRect into view</span><a class="self-link" href="#scroll-rect-into-view"></a></h4>
-   <div class="note" role="note"> This section describes a refactoring of the CSSOMVIEW’s <span spec-section="#scroll-an-element-into-view">scroll an element into view</span> algorithm 
+   <div class="note" role="note"> This section describes a refactoring of the CSSOMVIEW’s <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view①">scroll an element into view</a> algorithm 
   to separate the steps for scrolling a DOMRect into view, so it can be used to
   scroll a Range into view. </div>
-   <p>Move the <span spec-section="#scroll-an-element-into-view">scroll an element into
-view</span> algorithm’s steps 3-14 into a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="scroll a DOMRect into view" data-noexport id="scroll-a-domrect-into-view">scroll a DOMRect into
-view</dfn>, with input <a href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> <em>bounding
-box</em>, <span spec-section="#dictdef-scrollintoviewoptions">ScrollIntoViewOptions</span> dictionary <em>options</em>, and <span spec-section="#element">Element</span> <em>startingElement</em>. Also move the recursive behavior described at the top
-of the <span spec-section="#scroll-an-element-into-view">scroll an element into view</span> algorithm to the <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view">scroll a DOMRect into view</a> algorithm: "run these steps for
-each ancestor element or viewport <b>of <em>startingElement</em></b> that
-establishes a scrolling box <em>scrolling box</em>, in order of innermost to
-outermost scrolling box".</p>
+   <p>Move the <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view②">scroll an element into view</a> algorithm’s steps
+3-14 into a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-domrect-into-view">scroll a DOMRect into view</dfn>, with input <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrect" id="ref-for-domrect">DOMRect</a></code> <em>bounding box</em>, <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions" id="ref-for-dictdef-scrollintoviewoptions">ScrollIntoViewOptions</a></code> dictionary <em>options</em>, and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code> <em>startingElement</em>. Also move the
+recursive behavior described at the top of the <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view③">scroll an
+element into view</a> algorithm to the <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view">scroll a DOMRect into view</a> algorithm: "run these steps for each ancestor element or viewport <b>of <em>startingElement</em></b> that establishes a scrolling box <em>scrolling
+box</em>, in order of innermost to outermost scrolling box".</p>
    <div class="note" role="note"> <em>bounding box</em> is renamed from <em>element bounding border box</em>. </div>
-   <p>Replace steps 3-14 of the <span spec-section="#scroll-an-element-into-view">scroll an
-element into view</span> algorithm with a call to <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view①">scroll a DOMRect into view</a>:</p>
+   <p>Replace steps 3-14 of the <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view④">scroll an element into view</a> algorithm with a call to <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view①">scroll a DOMRect into view</a>:</p>
    <ol start="3">
     <li data-md>
      <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view②">scroll a DOMRect into view</a> on <em>element bounding border
 box</em> with options <em>options</em> and startingElement <em>element</em>.</p>
    </ol>
-   <p>Define a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-range-into-view">scroll a Range into view</dfn>, with input <span spec-section="#range">Range</span> <em>range</em>, <span spec-section="#element">Element</span> <em>containingElement</em>, and a <span spec-section="#dictdef-scrollintoviewoptions">ScrollIntoViewOptions</span> dictionary <em>options</em>:</p>
+   <p>Define a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-range-into-view">scroll a Range into view</dfn>, with input <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range④">Range</a></code> <em>range</em>, <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> <em>containingElement</em>, and a <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions" id="ref-for-dictdef-scrollintoviewoptions①">ScrollIntoViewOptions</a></code> dictionary <em>options</em>:</p>
    <ol>
     <li data-md>
-     <p>Let <em>bounding rect</em> be the <a href="https://drafts.fxtf.org/geometry-1/#domrect">DOMRect</a> that is
-the return value of invoking <span spec-section="#dom-range-getboundingclientrect">getBoundingClientRect()</span> on <em>range</em>.</p>
+     <p>Let <em>bounding rect</em> be the <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrect" id="ref-for-domrect①">DOMRect</a></code> that is the return value of
+   invoking <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect" id="ref-for-dom-range-getboundingclientrect">getBoundingClientRect()</a></code> on <em>range</em>.</p>
     <li data-md>
      <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view③">scroll a DOMRect into view</a> on <em>bounding rect</em> with <em>options</em> and startingElement <em>containingElement</em>.</p>
    </ol>
    <h4 class="heading settled" data-level="2.5.2" id="find-text-matches"><span class="secno">2.5.2. </span><span class="content">Find text matches</span><a class="self-link" href="#find-text-matches"></a></h4>
    <div class="note" role="note"> This algorithm has input <em>fragment directive input</em>, that is the raw
-fragment directive string, and returns a <span spec-section="#list">list</span> of <span spec-section="#range">Range</span>s that are to be visually indicated, and the first should be
+fragment directive <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑤">Range</a></code>s that are to be visually indicated, and the first should be
 scrolled into view. </div>
    <ol>
     <li data-md>
-     <p>If <em>fragment directive input</em> does not match the <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective③">FragmentDirective</a> production, then return an empty <span spec-section="#list">list</span>.</p>
+     <p>If <em>fragment directive input</em> does not match the <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective③">FragmentDirective</a> production, then return an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>.</p>
     <li data-md>
-     <p>Let <em>directives</em> be a <span spec-section="#list">list</span> of strings that is the
-result of <span spec-section="#strictly-split">splitting</span> <em>fragment directive
-input</em> on "&amp;".</p>
+     <p>Let <em>directives</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a>s
+that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split">strictly splitting the string</a> <em>fragment directive input</em> on "&amp;".</p>
     <li data-md>
-     <p>Let <em>ranges</em> be a <span spec-section="#list">list</span> of <span spec-section="#range">Range</span>s that is
+     <p>Let <em>ranges</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list④">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑥">Range</a></code>s that is
 initially empty.</p>
     <li data-md>
-     <p>For each string <em>directive</em> in <em>directives</em>:</p>
+     <p>For each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a> <em>directive</em> in <em>directives</em>:</p>
      <ol>
       <li data-md>
        <p>If <em>directive</em> does not match the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a>,
 then continue.</p>
       <li data-md>
        <p>If the result of <a href="#find-a-target-text">§ 2.5.3 Find a target text</a> on <em>directive</em> is
-non-null, then <span spec-section="#list-append">append</span> it to <em>ranges</em>.</p>
+non-null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> it to <em>ranges</em>.</p>
      </ol>
     <li data-md>
      <p>Return <em>ranges</em>.</p>
    </ol>
    <h4 class="heading settled" data-level="2.5.3" id="find-a-target-text"><span class="secno">2.5.3. </span><span class="content">Find a target text</span><a class="self-link" href="#find-a-target-text"></a></h4>
-   <p>To find the target text for a given string <em>text directive input</em>,
-the user agent must run these steps:</p>
+   <p>To find the target text for a given <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> <em>text
+directive input</em>, the user agent must run these steps:</p>
    <ol>
     <li data-md>
      <p>If <em>text directive input</em> does not begin with the string "text=",
@@ -2039,13 +2033,13 @@ but not including, the "text=" prefix. </div>
     <li data-md>
      <p>If <em>raw target text</em> is the empty string, return null.</p>
     <li data-md>
-     <p>Let <em>tokens</em> be a <span spec-section="#list">list</span> of strings that is the result of <span spec-section="#split-on-commas">splitting a string on commas</span> of <em>raw target
-text</em>.</p>
+     <p>Let <em>tokens</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a>s that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <em>raw target text</em> on
+commas</a>.</p>
     <li data-md>
      <p>Let <em>prefix</em> and <em>suffix</em> and <em>textEnd</em> be the empty
 string.</p>
      <div class="note" role="note"> prefix, suffix, and textEnd are the optional parameters of the text
-directive. </div>
+  directive. </div>
     <li data-md>
      <p>Let <em>potential prefix</em> be the first item of <em>tokens</em>.</p>
     <li data-md>
@@ -2054,33 +2048,32 @@ directive. </div>
       <li data-md>
        <p>Set <em>prefix</em> to the result of removing the last character from <em>potential prefix</em>.</p>
       <li data-md>
-       <p><span spec-section="#list-remove">Remove</span> the first item of the list <em>tokens</em>.</p>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> the first item of <em>tokens</em>.</p>
      </ol>
     <li data-md>
-     <p>Let <em>potential suffix</em> be the last item of <em>tokens</em>.</p>
+     <p>Let <em>potential suffix</em> be the last item from <em>tokens</em>.</p>
     <li data-md>
      <p>If the first character of <em>potential suffix</em> is U+002D (-), then:</p>
      <ol>
       <li data-md>
        <p>Set <em>suffix</em> to the result of removing the first character from <em>potential suffix</em>.</p>
       <li data-md>
-       <p><span spec-section="#list-remove">Remove</span> the last item of the list <em>tokens</em>.</p>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove①">Remove</a> the last item from <em>tokens</em>.</p>
      </ol>
     <li data-md>
-     <p class="assertion">Assert: <em>tokens</em> has <span spec-section="#list-size">size</span> 1 or <em>tokens</em> has <span spec-section="#list-size">size</span> 2.</p>
+     <p class="assertion">Assert: <em>tokens</em> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> 1 or <em>tokens</em> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size①">size</a> 2.</p>
      <div class="note" role="note"> Once the prefix and suffix are removed from tokens, tokens may either
 contain one item (textStart) or two items (textStart and textEnd). </div>
     <li data-md>
      <p>Let <em>textStart</em> be the first item of <em>tokens</em>.</p>
     <li data-md>
-     <p>If <em>tokens</em> has <span spec-section="#list-size">size</span> 2, then let <em>textEnd</em> be the last item of <em>tokens</em>.</p>
+     <p>If <em>tokens</em> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size②">size</a> 2, then let <em>textEnd</em> be the last item of <em>tokens</em>.</p>
      <div class="note" role="note"> The strings prefix, textStart, textEnd, and suffix now contain the
 text directive parameters as defined in <a href="#syntax">§ 2.2 Syntax</a>. </div>
     <li data-md>
-     <p>Let <em>walker</em> be a <span spec-section="#treewalker">TreeWalker</span> equal to <span spec-section="#dom-document-createtreewalker">Document.createTreeWalker()</span>.</p>
+     <p>Let <em>walker</em> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker">TreeWalker</a></code> equal to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createtreewalker" id="ref-for-dom-document-createtreewalker">createTreeWalker()</a></code>.</p>
     <li data-md>
-     <p>Let <em>position</em> be a <span spec-section="#string-position-variable">position
-variable</span> that indicates a text offset in <em>walker.currentNode.innerText</em>.</p>
+     <p>Let <em>position</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable①">position variable</a> that indicates a text offset in <em>walker.currentNode.innerText</em>.</p>
     <li data-md>
      <p>If textEnd is the empty string, then:</p>
      <ol>
@@ -2090,7 +2083,7 @@ prefix <em>prefix</em>, query <em>textStart</em>, and suffix <em>suffix</em>.</p
       <li data-md>
        <p>If <em>match position</em> is null, then return null.</p>
       <li data-md>
-       <p>Let <em>match</em> be a Range in <em>walker.currentNode</em> with
+       <p>Let <em>match</em> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑦">Range</a></code> in <em>walker.currentNode</em> with
 position <em>match position</em> and length equal to the length of <em>textStart</em>.</p>
       <li data-md>
        <p>Return <em>match</em>.</p>
@@ -2109,7 +2102,7 @@ position</em>, prefix <em>null</em>, query <em>textEnd</em>, and suffix <em>suff
     <li data-md>
      <p>Advance <em>end position</em> by the length of <em>textEnd</em>.</p>
     <li data-md>
-     <p>Let <em>match</em> be a Range in <em>walker.currentNode</em> with start
+     <p>Let <em>match</em> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑧">Range</a></code> in <em>walker.currentNode</em> with start
 position <em>potential start position</em> and length equal to <em>end
 position - start position</em>.</p>
     <li data-md>
@@ -2117,8 +2110,8 @@ position - start position</em>.</p>
    </ol>
    <h4 class="heading settled" data-level="2.5.4" id="find-match-with-context"><span class="secno">2.5.4. </span><span class="content">Find an exact match with context</span><a class="self-link" href="#find-match-with-context"></a></h4>
    <div class="note" role="note"> This algorithm has input <em>walker, search position, prefix, query,</em> and <em>suffix</em> and returns a text position that is the start of the match. </div>
-   <div class="note" role="note"> The input <em>walker</em> is a <span spec-section="#treewalker">TreeWalker</span> reference, not a
-copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
+   <div class="note" role="note"> The input <em>walker</em> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker①">TreeWalker</a></code> reference, not a copy, i.e. any
+  modifications are performed on the caller’s instance of <em>walker</em>. </div>
    <ol>
     <li data-md>
      <p>While <em>walker.currentNode</em> is not null:</p>
@@ -2140,7 +2133,8 @@ locale</a>.</p>
           <li data-md>
            <p>If <em>search position</em> is null, then break.</p>
           <li data-md>
-           <p><span spec-section="#skip-ascii-whitespace">Skip ASCII whitespace</span> on <em>search position</em>.</p>
+           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace">Skip ASCII whitespace</a> on <em>search
+position</em>.</p>
           <li data-md>
            <p>If <em>search position</em> is at the end of <em>text</em>, then:</p>
            <ol>
@@ -2153,7 +2147,8 @@ locale</a>.</p>
             <li data-md>
              <p>Set <em>search position</em> to the beginning of <em>text</em>.</p>
             <li data-md>
-             <p><span spec-section="#skip-ascii-whitespace">Skip ASCII whitespace</span> on <em>search position</em>.</p>
+             <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace①">Skip ASCII whitespace</a> on <em>search
+position</em>.</p>
            </ol>
           <li data-md>
            <p>If the result of <a href="#next-word-bounded-instance">§ 2.5.6 Find the next word bounded instance</a> of <em>query</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale①">current locale</a> does not start at <em>search
@@ -2161,24 +2156,25 @@ position</em>, then continue.</p>
          </ol>
         <li data-md>
          <p>Advance <em>search position</em> to the position after the result of <a href="#next-word-bounded-instance">§ 2.5.6 Find the next word bounded instance</a> of <em>query</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale②">current locale</a>.</p>
-         <div class="note" role="note"> If a prefix was specified, the search position is at the beginning
-of <em>query</em> and this will advance it to the end of the query
-to search for a potential suffix. Otherwise, this will find the next
-instance of query. </div>
+         <div class="note" role="note"> If a prefix was specified, the search position is at the
+  beginning of <em>query</em> and this will advance it to the end
+  of the query to search for a potential suffix. Otherwise, this
+  will find the next instance of query. </div>
         <li data-md>
          <p>If <em>search position</em> is null, then break.</p>
         <li data-md>
-         <p>Let <em>potential match position</em> be a <span spec-section="#string-position-variable">position variable</span> equal to <em>search position</em> minus the length of <em>query</em>.</p>
+         <p>Let <em>potential match position</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable②">position variable</a> equal to <em>search
+position</em> minus the length of <em>query</em>.</p>
         <li data-md>
          <p>If <em>suffix</em> is the empty string, then return <em>potential
 match position</em>.</p>
         <li data-md>
-         <p><span spec-section="#skip-ascii-whitespace">Skip ASCII whitespace</span> on <em>search position</em>.</p>
+         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace②">Skip ASCII whitespace</a> on <em>search position</em>.</p>
         <li data-md>
          <p>If <em>search position</em> is at the end of <em>text</em>, then:</p>
          <ol>
           <li data-md>
-           <p>Let <em>suffix_walker</em> be a <span spec-section="#treewalker">TreeWalker</span> that is a copy of <em>walker</em>.</p>
+           <p>Let <em>suffix_walker</em> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker②">TreeWalker</a></code> that is a copy of <em>walker</em>.</p>
           <li data-md>
            <p>Perform <a href="#advance-walker-to-text">§ 2.5.5 Advance a TreeWalker to the next text node</a> on <em>suffix_walker</em>.</p>
           <li data-md>
@@ -2188,7 +2184,8 @@ match position</em>.</p>
           <li data-md>
            <p>Set <em>search position</em> to the beginning of <em>text</em>.</p>
           <li data-md>
-           <p><span spec-section="#skip-ascii-whitespace">Skip ASCII whitespace</span> on <em>search position</em>.</p>
+           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace③">Skip ASCII whitespace</a> on <em>search
+position</em>.</p>
          </ol>
         <li data-md>
          <p>If the result of <a href="#next-word-bounded-instance">§ 2.5.6 Find the next word bounded instance</a> of <em>suffix</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale③">current
@@ -2200,16 +2197,16 @@ locale</a> starts at <em>search position</em>, then return <em>potential match p
     <li data-md>
      <p>Return null.</p>
    </ol>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="current-locale">current locale</dfn> is the <a href="https://html.spec.whatwg.org/multipage/dom.html#language">language</a> of the <em>currentNode</em>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="current-locale">current locale</dfn> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#language" id="ref-for-language">language</a> of the <em>currentNode</em>.</p>
    <h4 class="heading settled" data-level="2.5.5" id="advance-walker-to-text"><span class="secno">2.5.5. </span><span class="content">Advance a TreeWalker to the next text node</span><a class="self-link" href="#advance-walker-to-text"></a></h4>
-   <div class="note" role="note"> The input <em>walker</em> is a <span spec-section="#treewalker">TreeWalker</span> reference, not a
-copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
+   <div class="note" role="note"> The input <em>walker</em> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker③">TreeWalker</a></code> reference, not a
+  copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
    <ol>
     <li data-md>
      <p>While the input <em>walker.currentNode</em> is not null and <em>walker.currentNode</em> is not a text node:</p>
      <ol>
       <li data-md>
-       <p>Advance the current node by calling <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode"> walker.nextNode()</a></p>
+       <p>Advance the current node by calling <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode" id="ref-for-dom-treewalker-nextnode">walker.nextNode()</a></code>.</p>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="2.5.6" id="next-word-bounded-instance"><span class="secno">2.5.6. </span><span class="content">Find the next word bounded instance</span><a class="self-link" href="#next-word-bounded-instance"></a></h4>
@@ -2255,8 +2252,8 @@ bound</em> immediately follows <em>range</em>, then return <em>range</em>.</p>
      <p>Return <em>null</em>.</p>
    </ol>
    <h3 class="heading settled" data-level="2.6" id="indicating-the-text-match"><span class="secno">2.6. </span><span class="content">Indicating The Text Match</span><a class="self-link" href="#indicating-the-text-match"></a></h3>
-   <p>The UA may choose to scroll the text fragment into view as part of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment"> Try To Scroll To The Fragment</a> steps or by some other mechanism; however, it
-is not required to scroll the match into view.</p>
+   <p>The UA may choose to scroll the text fragment into view as part of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment①">try to scroll to the fragment</a> steps or by some other mechanism;
+however, it is not required to scroll the match into view.</p>
    <p>The UA should visually indicate the matched text in some way such that the user
 is made aware of the text match, such as with a high-contrast highlight.</p>
    <p>The UA should provide to the user some method of dismissing the match, such
@@ -2273,8 +2270,8 @@ supports the feature.</p>
 <pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="fragmentdirective①"><code><c- g>FragmentDirective</c-></code></dfn> {
 };
 </pre>
-   <p>We amend <a href="https://html.spec.whatwg.org/multipage/history.html#the-location-interface"> The Location Interface</a> to include a <code>fragmentDirective</code> property:</p>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="idl-code" data-dfn-type="interface" data-export id="location"><code><c- g>Location</c-></code><a class="self-link" href="#location"></a></dfn> {
+   <p>We amend the <code class="idl"><a data-link-type="idl" href="#location" id="ref-for-location">Location</a></code> interface to include a <code>fragmentDirective</code> property:</p>
+<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="location"><code><c- g>Location</c-></code></dfn> {
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective①" id="ref-for-fragmentdirective①"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-location-fragmentdirective"></a></dfn>;
 };
 </pre>
@@ -2556,11 +2553,329 @@ match based on whether the element-id was scrolled.</p>
    <li><a href="#unknowndirective">UnknownDirective</a><span>, in §2.3.2</span>
    <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §2.3.2</span>
   </ul>
+  <aside class="dfn-panel" data-for="term-for-dictdef-scrollintoviewoptions">
+   <a href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions">https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-scrollintoviewoptions">2.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-dictdef-scrollintoviewoptions①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-range-getboundingclientrect">
+   <a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-range-getboundingclientrect">2.5.1. Scroll a DOMRect into view</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-scroll-an-element-into-view">
+   <a href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view">https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-scroll-an-element-into-view">2.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-scroll-an-element-into-view①">2.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-an-element-into-view②">(2)</a> <a href="#ref-for-scroll-an-element-into-view③">(3)</a> <a href="#ref-for-scroll-an-element-into-view④">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-document">
+   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-document">2.4.4. Should Allow Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-node-element_node">
+   <a href="https://dom.spec.whatwg.org/#dom-node-element_node">https://dom.spec.whatwg.org/#dom-node-element_node</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-node-element_node">2.5. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-element">
+   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-element">2.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-element①">2.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-element②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-range">
+   <a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-range">2.5. Navigating to a Text Fragment</a> <a href="#ref-for-range①">(2)</a> <a href="#ref-for-range②">(3)</a> <a href="#ref-for-range③">(4)</a>
+    <li><a href="#ref-for-range④">2.5.1. Scroll a DOMRect into view</a>
+    <li><a href="#ref-for-range⑤">2.5.2. Find text matches</a> <a href="#ref-for-range⑥">(2)</a>
+    <li><a href="#ref-for-range⑦">2.5.3. Find a target text</a> <a href="#ref-for-range⑧">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-treewalker">
+   <a href="https://dom.spec.whatwg.org/#treewalker">https://dom.spec.whatwg.org/#treewalker</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-treewalker">2.5.3. Find a target text</a>
+    <li><a href="#ref-for-treewalker①">2.5.4. Find an exact match with context</a> <a href="#ref-for-treewalker②">(2)</a>
+    <li><a href="#ref-for-treewalker③">2.5.5. Advance a TreeWalker to the next text node</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-range-commonancestorcontainer">
+   <a href="https://dom.spec.whatwg.org/#dom-range-commonancestorcontainer">https://dom.spec.whatwg.org/#dom-range-commonancestorcontainer</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-range-commonancestorcontainer">2.5. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-document-createtreewalker">
+   <a href="https://dom.spec.whatwg.org/#dom-document-createtreewalker">https://dom.spec.whatwg.org/#dom-document-createtreewalker</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-document-createtreewalker">2.5.3. Find a target text</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document">
+   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document">2.3.1. Parsing the fragment directive</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-treewalker-nextnode">
+   <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode">https://dom.spec.whatwg.org/#dom-treewalker-nextnode</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-treewalker-nextnode">2.5.5. Advance a TreeWalker to the next text node</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-node-nodetype">
+   <a href="https://dom.spec.whatwg.org/#dom-node-nodetype">https://dom.spec.whatwg.org/#dom-node-nodetype</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-node-nodetype">2.5. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-node-parentnode">
+   <a href="https://dom.spec.whatwg.org/#dom-node-parentnode">https://dom.spec.whatwg.org/#dom-node-parentnode</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-node-parentnode">2.5. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-url">
+   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-url">2.3.1. Parsing the fragment directive</a> <a href="#ref-for-concept-document-url①">(2)</a> <a href="#ref-for-concept-document-url②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-current-url">2.3.1. Parsing the fragment directive</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-response-url">
+   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-response-url">2.3.1. Parsing the fragment directive</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-domrect">
+   <a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domrect">2.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-domrect①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-browsing-context">2.4.4. Should Allow Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-browsing-context-set">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-set">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-set</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-browsing-context-set">2.4.4. Should Allow Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-language">
+   <a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-language">2.5.4. Find an exact match with context</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-latest-entry">
+   <a href="https://html.spec.whatwg.org/multipage/history.html#latest-entry">https://html.spec.whatwg.org/multipage/history.html#latest-entry</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-latest-entry">2.4.4. Should Allow Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-scroll-to-the-fragment-identifier">
+   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier">https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier">2.4.5. allowTextFragmentDirective flag</a>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier①">2.5. Navigating to a Text Fragment</a> <a href="#ref-for-scroll-to-the-fragment-identifier②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-session-history">
+   <a href="https://html.spec.whatwg.org/multipage/history.html#session-history">https://html.spec.whatwg.org/multipage/history.html#session-history</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-session-history">2.4.4. Should Allow Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-indicated-part-of-the-document">
+   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-indicated-part-of-the-document">2.5. Navigating to a Text Fragment</a> <a href="#ref-for-the-indicated-part-of-the-document①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-try-to-scroll-to-the-fragment">
+   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-try-to-scroll-to-the-fragment">2.4.5. allowTextFragmentDirective flag</a>
+    <li><a href="#ref-for-try-to-scroll-to-the-fragment①">2.6. Indicating The Text Match</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-append">
+   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-append">2.5.2. Find text matches</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list">
+   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list">2.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-list①">2.5.2. Find text matches</a> <a href="#ref-for-list②">(2)</a> <a href="#ref-for-list③">(3)</a> <a href="#ref-for-list④">(4)</a>
+    <li><a href="#ref-for-list⑤">2.5.3. Find a target text</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-string-position-variable">
+   <a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-string-position-variable">2.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-string-position-variable①">2.5.3. Find a target text</a>
+    <li><a href="#ref-for-string-position-variable②">2.5.4. Find an exact match with context</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-remove">
+   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-remove">2.5.3. Find a target text</a> <a href="#ref-for-list-remove①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-list-size">
+   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-list-size">2.5.3. Find a target text</a> <a href="#ref-for-list-size①">(2)</a> <a href="#ref-for-list-size②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-skip-ascii-whitespace">
+   <a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">https://infra.spec.whatwg.org/#skip-ascii-whitespace</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-skip-ascii-whitespace">2.5.4. Find an exact match with context</a> <a href="#ref-for-skip-ascii-whitespace①">(2)</a> <a href="#ref-for-skip-ascii-whitespace②">(3)</a> <a href="#ref-for-skip-ascii-whitespace③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-split-on-commas">
+   <a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-split-on-commas">2.5.3. Find a target text</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-strictly-split">
+   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-strictly-split">2.5.2. Find text matches</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-string">
+   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-string">2.5.2. Find text matches</a> <a href="#ref-for-string①">(2)</a> <a href="#ref-for-string②">(3)</a>
+    <li><a href="#ref-for-string③">2.5.3. Find a target text</a> <a href="#ref-for-string④">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
+   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url-fragment">2.3.1. Parsing the fragment directive</a> <a href="#ref-for-concept-url-fragment①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-url-code-points">
+   <a href="https://url.spec.whatwg.org/#url-code-points">https://url.spec.whatwg.org/#url-code-points</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-url-code-points">2.3.2. Fragment directive grammar</a>
+   </ul>
+  </aside>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[cssom-view-1]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-dictdef-scrollintoviewoptions" style="color:initial">ScrollIntoViewOptions</span>
+     <li><span class="dfn-paneled" id="term-for-dom-range-getboundingclientrect" style="color:initial">getBoundingClientRect()</span>
+     <li><span class="dfn-paneled" id="term-for-scroll-an-element-into-view" style="color:initial">scroll an element into view</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[DOM]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-document" style="color:initial">Document</span>
+     <li><span class="dfn-paneled" id="term-for-dom-node-element_node" style="color:initial">ELEMENT_NODE</span>
+     <li><span class="dfn-paneled" id="term-for-element" style="color:initial">Element</span>
+     <li><span class="dfn-paneled" id="term-for-range" style="color:initial">Range</span>
+     <li><span class="dfn-paneled" id="term-for-treewalker" style="color:initial">TreeWalker</span>
+     <li><span class="dfn-paneled" id="term-for-dom-range-commonancestorcontainer" style="color:initial">commonAncestorContainer</span>
+     <li><span class="dfn-paneled" id="term-for-dom-document-createtreewalker" style="color:initial">createTreeWalker(root)</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document" style="color:initial">document</span>
+     <li><span class="dfn-paneled" id="term-for-dom-treewalker-nextnode" style="color:initial">nextNode()</span>
+     <li><span class="dfn-paneled" id="term-for-dom-node-nodetype" style="color:initial">nodeType</span>
+     <li><span class="dfn-paneled" id="term-for-dom-node-parentnode" style="color:initial">parentNode</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-url" style="color:initial">url</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[FETCH]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-concept-request-current-url" style="color:initial">current url</span>
+     <li><span class="dfn-paneled" id="term-for-concept-response-url" style="color:initial">url</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[geometry-1]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-domrect" style="color:initial">DOMRect</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-browsing-context" style="color:initial">browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-browsing-context-set" style="color:initial">browsing context set</span>
+     <li><span class="dfn-paneled" id="term-for-language" style="color:initial">language</span>
+     <li><span class="dfn-paneled" id="term-for-latest-entry" style="color:initial">latest entry</span>
+     <li><span class="dfn-paneled" id="term-for-scroll-to-the-fragment-identifier" style="color:initial">scroll to the fragment</span>
+     <li><span class="dfn-paneled" id="term-for-session-history" style="color:initial">session history</span>
+     <li><span class="dfn-paneled" id="term-for-the-indicated-part-of-the-document" style="color:initial">the indicated part of the document</span>
+     <li><span class="dfn-paneled" id="term-for-try-to-scroll-to-the-fragment" style="color:initial">try to scroll to the fragment</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-list-append" style="color:initial">append</span>
+     <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
+     <li><span class="dfn-paneled" id="term-for-string-position-variable" style="color:initial">position variable</span>
+     <li><span class="dfn-paneled" id="term-for-list-remove" style="color:initial">remove</span>
+     <li><span class="dfn-paneled" id="term-for-list-size" style="color:initial">size</span>
+     <li><span class="dfn-paneled" id="term-for-skip-ascii-whitespace" style="color:initial">skip ascii whitespace</span>
+     <li><span class="dfn-paneled" id="term-for-split-on-commas" style="color:initial">split on commas</span>
+     <li><span class="dfn-paneled" id="term-for-strictly-split" style="color:initial">strictly split a string</span>
+     <li><span class="dfn-paneled" id="term-for-string" style="color:initial">string</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[URL]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-concept-url-fragment" style="color:initial">fragment</span>
+     <li><span class="dfn-paneled" id="term-for-url-code-points" style="color:initial">url code point</span>
+    </ul>
+  </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-cssom-view-1">[CSSOM-VIEW-1]
+   <dd>Simon Pieters. <a href="https://www.w3.org/TR/cssom-view-1/">CSSOM View Module</a>. 17 March 2016. WD. URL: <a href="https://www.w3.org/TR/cssom-view-1/">https://www.w3.org/TR/cssom-view-1/</a>
+   <dt id="biblio-dom">[DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dt id="biblio-fetch">[FETCH]
+   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-geometry-1">[GEOMETRY-1]
+   <dd>Simon Pieters; Chris Harrelson. <a href="https://www.w3.org/TR/geometry-1/">Geometry Interfaces Module Level 1</a>. 4 December 2018. CR. URL: <a href="https://www.w3.org/TR/geometry-1/">https://www.w3.org/TR/geometry-1/</a>
+   <dt id="biblio-html">[HTML]
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-url">[URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>interface</c-> <a href="#fragmentdirective①"><code><c- g>FragmentDirective</c-></code></a> {
@@ -2678,6 +2993,12 @@ match based on whether the element-id was scrolled.</p>
    <b><a href="#fragmentdirective①">#fragmentdirective①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentdirective①">2.7. Feature Detectability</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="location">
+   <b><a href="#location">#location</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-location">2.7. Feature Detectability</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
We were erroneously using the section autolink format where we intended
to link to definitions and interfaces.

Fixes #77