### PR TITLE
[Spec] Factor out parsing logic

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -575,14 +575,14 @@ Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
   </p>
 </div>
 
-1. Let <var>raw target text</var> be the substring of <em>text directive
+1. Let |raw target text| be the substring of <em>text directive
    input</em> starting at index 5.
    <div class="note">
      This is the remainder of the <em>text directive input</em> following,
      but not including, the "text=" prefix.
    </div>
 1. Let <var>tokens</var> be a <a for=/>list</a> of strings that is the result of
-   <a lt="split on commas">splitting <var>raw target text</var> on commas</a>.
+   <a lt="split on commas">splitting |raw target text| on commas</a>.
 1. If <var>tokens</var> has size less than 1 or greater than 4, return null.
 1. If any of <var>tokens</var>' items are the empty string, return null.
 1. Let <var>retVal</var> be a <a spec=infra>struct</a> consisting of four strings:
@@ -630,7 +630,7 @@ these steps:
    {{Document/createTreeWalker()|document.createTreeWalker()}}.
 1. Let |position| be a <a spec=infra for=string>position variable</a>
    that indicates a text offset in <em>walker.currentNode.innerText</em>.
-1. If |textEnd| is the empty string, then:
+1. If |textEnd| is null, then:
      1. Let |match position| be the result of [[#find-match-with-context]]
         with input walker |walker|, search position |position|,
         prefix |prefix|, query |textStart|, and suffix |suffix|.
@@ -669,7 +669,7 @@ these steps:
     2. Let |text| be equal to <em>walker.currentNode.innerText</em>.
     3. While |search position| does not point past the end of
         |text|:
-        1. If |prefix| is not the empty string, then:
+        1. If |prefix| is not null, then:
             1. Advance |search position| to the position after the result
                 of [[#next-word-bounded-instance]] of |prefix| in
                 |text| from |search position| with [=current
@@ -702,7 +702,7 @@ these steps:
         4. Let |potential match position| be a
             <a spec=infra for=string>position variable</a> equal to |search
             position| minus the length of |query|.
-        5. If |suffix| is the empty string, then return |potential
+        5. If |suffix| is null, then return |potential
             match position|.
         6. <a spec=infra>Skip ASCII whitespace</a> on |search position|.
         7. If |search position| is at the end of |text|, then:

--- a/index.bs
+++ b/index.bs
@@ -13,6 +13,10 @@ Group: wicg
 Repository: wicg/ScrollToTextFragment
 </pre>
 
+<h2 id=infrastructure>Infrastructure</h2>
+
+<p>This specification depends on the Infra Standard. [[!INFRA]]
+
 # Introduction # {#introduction}
 
 <div class='note'>This section is non-normative</div>
@@ -365,7 +369,7 @@ has been successfully found</em>.
 This specification does not specify exactly how a UA achieves this as there are
 multiple solutions with differing tradeoffs. For example, a UA <em>may</em>
 continue to walk the tree even after a match is found in
-[[#find-a-target-text]].  Alternatively, it <em>may</em> schedule an
+[[#find-a-matching-range]].  Alternatively, it <em>may</em> schedule an
 asynchronous task to find and set the indicated part of the document.
 
 ### Should Allow Text Fragment ### {#should-allow-text-fragment}
@@ -533,10 +537,10 @@ Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
 ### Find text matches ### {#find-text-matches}
 
 <div class="note">
-This algorithm has input <em>fragment directive input</em>, that is the raw
-fragment directive <a spec=infra>string</a>, and returns a <a spec=infra>list</a> of
-{{Range}}s that are to be visually indicated, and the first should be
-scrolled into view.
+  This algorithm has input <em>fragment directive input</em>, that is the raw
+  fragment directive <a spec=infra>string</a>, and returns a
+  <a spec=infra>list</a> of {{Range}}s that are to be visually indicated, the
+  first of which should be scrolled into view.
 </div>
 
 1. If <em>fragment directive input</em> does not match the [=FragmentDirective=]
@@ -549,156 +553,177 @@ scrolled into view.
 4. For each <a spec=infra>string</a> <em>directive</em> in <em>directives</em>:
     1. If <em>directive</em> does not match the production [=TextDirective=],
         then continue.
-    2. If the result of [[#find-a-target-text]] on <em>directive</em> is
+    2. If the result of [[#find-a-matching-range]] on <em>directive</em> is
         non-null, then <a spec=infra for=list>append</a> it to <em>ranges</em>.
 5. Return <em>ranges</em>.
 
-### Find a target text ### {#find-a-target-text}
+### Parse a text directive ### {#parse-a-text-directive}
 
-To find the target text for a given <a spec=infra>string</a> <em>text
-directive input</em>, the user agent must run these steps:
-1. If <em>text directive input</em> does not begin with the string "text=",
-    then return null.
-2. Let <em>raw target text</em> be the substring of <em>text directive
-    input</em> starting at index 5.
-    <div class="note">
-    This is the remainder of the <em>text directive input</em> following,
-    but not including, the "text=" prefix.
-    </div>
-3. If <em>raw target text</em> is the empty string, return null.
-4. Let <em>tokens</em> be a <a spec=infra>list</a> of
-    <a spec="infra">string</a>s that is the result of
-    <a spec=infra lt="split on commas">splitting <em>raw target text</em> on
-    commas</a>.
-5. Let <em>prefix</em> and <em>suffix</em> and <em>textEnd</em> be the empty
-    string.
-    <div class="note">
-      prefix, suffix, and textEnd are the optional parameters of the text
-      directive.
-    </div>
-6. Let <em>potential prefix</em> be the first item of <em>tokens</em>.
-7. If the last character of <em>potential prefix</em> is U+002D (-), then:
-    1. Set <em>prefix</em> to the result of removing the last character from
-        <em>potential prefix</em>.
-    2. <a spec=infra for=list>Remove</a> the first item of <em>tokens</em>.
-8. Let <em>potential suffix</em> be the last item from <em>tokens</em>.
-9. If the first character of <em>potential suffix</em> is U+002D (-), then:
-    1. Set <em>suffix</em> to the result of removing the first character from
-        <em>potential suffix</em>.
-    2. <a spec=infra for=list>Remove</a> the last item from <em>tokens</em>.
-10. Assert: <em>tokens</em> has <a spec=infra for=list>size</a> 1 or <em>tokens</em>
-    has <a spec=infra for=list>size</a> 2.
-    <div class="note">
-    Once the prefix and suffix are removed from tokens, tokens may either
-    contain one item (textStart) or two items (textStart and textEnd).
-    </div>
-11. Let <em>textStart</em> be the first item of <em>tokens</em>.
-12. If <em>tokens</em> has <a spec=infra for=list>size</a> 2, then let <em>textEnd</em>
-    be the last item of <em>tokens</em>.
-    <div class="note">
-    The strings prefix, textStart, textEnd, and suffix now contain the
-    text directive parameters as defined in [[#syntax]].
-    </div>
-13. Let <em>walker</em> be a {{TreeWalker}} equal to
-    {{Document/createTreeWalker()}}.
-14. Let <em>position</em> be a <a spec=infra for=string>position variable</a>
-    that indicates a text offset in <em>walker.currentNode.innerText</em>.
-15. If textEnd is the empty string, then:
-    1. Let <em>match position</em> be the result of [[#find-match-with-context]]
-        with input walker <em>walker</em>, search position <em>position</em>,
-        prefix <em>prefix</em>, query <em>textStart</em>, and suffix
-        <em>suffix</em>.
-    2. If <em>match position</em> is null, then return null.
-    3. Let <em>match</em> be a {{Range}} in <em>walker.currentNode</em> with
-        position <em>match position</em> and length equal to the length of
-        <em>textStart</em>.
-    4. Return <em>match</em>.
-16. Otherwise, let <em>potential start position</em> be the result of
-    [[#find-match-with-context]] with input walker <em>walker</em>, start
-    position <em>position</em>, prefix <em>prefix</em>, query
-    <em>textStart</em>, and suffix <em>null</em>.
-17. If <em>potential start position</em> is null, then return null.
-18. Let <em>end position</em> be the result of [[#find-match-with-context]] with
-    input walker <em>walker</em>, search position <em>potential start
-    position</em>, prefix <em>null</em>, query <em>textEnd</em>, and suffix
-    <em>suffix</em>.
-19. If <em>end position</em> is null, then return null.
-20. Advance <em>end position</em> by the length of <em>textEnd</em>.
-21. Let <em>match</em> be a {{Range}} in <em>walker.currentNode</em> with start 
-    position <em>potential start position</em> and length equal to <em>end
-    position - start position</em>.
-22. Return <em>match</em>.
+<div class="note">
+  <p>
+    This algorithm takes a single text directive string as input (e.g.
+    "text=prefix-,foo,bar") and attempts to parse the string into the
+    components of the directive (e.g. "prefix", "foo", "bar"). See [[#syntax]]
+    for the what each of these components means and how they're used.
+  </p>
+  <p>
+    Returns null if the input is invalid or fails to parse in any way.
+    Otherwise, returns a <a spec=infra>struct</a> containing four strings:
+    <em>textStart</em>, <em>textEnd</em>, <em>prefix</em>, <em>suffix</em>.
+    Only <em>textStart</em> is required to be non-null as the other parameters
+    are optional and may be omitted in a valid text directive string.
+  </p>
+</div>
+
+1. Let <var>raw target text</var> be the substring of <em>text directive
+   input</em> starting at index 5.
+   <div class="note">
+     This is the remainder of the <em>text directive input</em> following,
+     but not including, the "text=" prefix.
+   </div>
+1. Let <var>tokens</var> be a <a for=/>list</a> of strings that is the result of
+   <a lt="split on commas">splitting <var>raw target text</var> on commas</a>.
+1. If <var>tokens</var> has size less than 1 or greater than 4, return null.
+1. If any of <var>tokens</var>' items are the empty string, return null.
+1. Let <var>retVal</var> be a <a spec=infra>struct</a> consisting of four strings:
+   <em>textStart</em>, <em>textEnd</em>, <em>prefix</em> and
+   <em>suffix</em>, each initialized to null.
+1. Let <var>potential prefix</var> be the first item of <var>tokens</var>.
+1. If the last character of <em>potential prefix</em> is U+002D (-), then:
+   1. Set <em>retVal.prefix</em> to the result of removing the last character from
+      <em>potential prefix</em>.
+   1. <a spec=infra for=list>Remove</a> the first item of the list <var>tokens</var>.
+1. Let <em>potential suffix</em> be the last item of <var>tokens</var>, if one exists.
+1. If the first character of <em>potential suffix</em> is U+002D (-), then:
+    1. Set <em>retVal.suffix</em> to the result of removing the first character from
+       <em>potential suffix</em>.
+    1. <a spec=infra for=list>Remove</a> the last item of the list <var>tokens</var>.
+1. If <var>tokens</var> has <a spec=infra for=list>size</a> not equal to 1 nor 2 then
+   return null.
+1. Let <em>retVal.textStart</em> be the first item of <var>tokens</var>.
+1. If <var>tokens</var> has <a spec=infra for=list>size</a> 2, then let
+   <em>retVal.textEnd</em> be the last item of <var>tokens</var>.
+1. Return <var>retVal</var>
+
+### Find a matching Range ### {#find-a-matching-range}
+
+<div class="note">
+  <p>
+    This algorithm takes a single <a spec=infra>string</a> |directive| as
+    input (e.g.  "text=prefix-,foo,bar") and returns the first {{Range}} in the
+    {{Document}} that corresponds to the match string(s) in the text directive
+    and satisfies the prefix and suffix (if given).  Returns null if no such
+    {{Range}} exists.
+  </p>
+</div>
+
+To find the target text for a given string |directive|, the user agent must run
+these steps:
+1. If |directive| does not begin with the string "text=",
+   then return null.
+1. Let |parsed values| be the result of running
+   [[#parse-a-text-directive]] on |directive|.
+1. If <em>parsed values</em> is null, return null.
+1. Let |prefix|, |textStart|, |textEnd|, and |suffix| be the values of the
+   equivalent items in |parsed values|.
+1. Let |walker| be a {{TreeWalker}} equal to
+   {{Document/createTreeWalker()|document.createTreeWalker()}}.
+1. Let |position| be a <a spec=infra for=string>position variable</a>
+   that indicates a text offset in <em>walker.currentNode.innerText</em>.
+1. If |textEnd| is the empty string, then:
+     1. Let |match position| be the result of [[#find-match-with-context]]
+        with input walker |walker|, search position |position|,
+        prefix |prefix|, query |textStart|, and suffix |suffix|.
+     1. If |match position| is null, return null.
+     1. Let |match| be a {{Range}} in <em>walker.currentNode</em> with
+        position |match position| and length equal to the <a spec=infra
+        for=string>length</a> of |textStart|.
+     1. Return |match|.
+1. Otherwise, let |potential start position| be the result of
+   [[#find-match-with-context]] with input walker |walker|, start position
+   |position|, prefix |prefix|, query |textStart|, and suffix |null|.
+1. If |potential start position| is null, then return null.
+1. Let |end position| be the result of [[#find-match-with-context]] with input
+   walker |walker|, search position |potential start position|, prefix |null|,
+   query |textEnd|, and suffix |suffix|.
+1. If |end position| is null, then return null.
+1. Advance |end position| by the length of |textEnd|.
+1. Let |match| be a {{Range}} in <em>walker.currentNode</em> with start
+   position |potential start position| and length equal to |end position| - |start
+   position|.
+1. Return |match|.
 
 ### Find an exact match with context ### {#find-match-with-context}
+
 <div class="note">
-This algorithm has input <em>walker, search position, prefix, query,</em> and
-<em>suffix</em> and returns a text position that is the start of the match.
+  This algorithm has input |walker|, |search position|, |prefix|, |query|, and
+  |suffix| and returns a text position that is the start of the match.
 </div>
 <div class="note">
-  The input <em>walker</em> is a {{TreeWalker}} reference, not a copy, i.e. any
-  modifications are performed on the caller's instance of <em>walker</em>.
+  The input |walker| is a {{TreeWalker}} reference, not a copy, i.e. any
+  modifications are performed on the caller's instance of |walker|.
 </div>
 
 1. While <em>walker.currentNode</em> is not null:
     1. Assert: <em>walker.currentNode</em> is a text node.
-    2. Let <em>text</em> be equal to <em>walker.currentNode.innerText</em>.
-    3. While <em>search position</em> does not point past the end of
-        <em>text</em>:
-        1. If <em>prefix</em> is not the empty string, then:
-            1. Advance <em>search position</em> to the position after the result
-                of [[#next-word-bounded-instance]] of <em>prefix</em> in
-                <em>text</em> from <em>search position</em> with [=current
+    2. Let |text| be equal to <em>walker.currentNode.innerText</em>.
+    3. While |search position| does not point past the end of
+        |text|:
+        1. If |prefix| is not the empty string, then:
+            1. Advance |search position| to the position after the result
+                of [[#next-word-bounded-instance]] of |prefix| in
+                |text| from |search position| with [=current
                 locale=].
-            2. If <em>search position</em> is null, then break.
-            3. <a spec=infra>Skip ASCII whitespace</a> on <em>search
-                position</em>.
-            4. If <em>search position</em> is at the end of <em>text</em>, then:
-                1. Perform [[#advance-walker-to-text]] on <em>walker</em>.
+            2. If |search position| is null, then break.
+            3. <a spec=infra>Skip ASCII whitespace</a> on |search
+                position|.
+            4. If |search position| is at the end of |text|, then:
+                1. Perform [[#advance-walker-to-text]] on |walker|.
                 2. If <em>walker.currentNode</em> is null, then return null.
-                3. Set <em>text</em> to <em>walker.currentNode.innerText</em>.
-                4. Set <em>search position</em> to the beginning of
-                    <em>text</em>.
-                5. <a spec=infra>Skip ASCII whitespace</a> on <em>search
-                    position</em>.
+                3. Set |text| to <em>walker.currentNode.innerText</em>.
+                4. Set |search position| to the beginning of
+                    |text|.
+                5. <a spec=infra>Skip ASCII whitespace</a> on |search
+                    position|.
             5. If the result of [[#next-word-bounded-instance]] of
-                <em>query</em> in <em>text</em> from <em>search position</em> 
-                with [=current locale=] does not start at <em>search
-                position</em>, then continue.
-        2. Advance <em>search position</em> to the position after the result of
-            [[#next-word-bounded-instance]] of <em>query</em> in <em>text</em>
-            from <em>search position</em> with [=current locale=].
+                |query| in |text| from |search position| 
+                with [=current locale=] does not start at |search
+                position|, then continue.
+        2. Advance |search position| to the position after the result of
+            [[#next-word-bounded-instance]] of |query| in |text|
+            from |search position| with [=current locale=].
             <div class="note">
               If a prefix was specified, the search position is at the
-              beginning of <em>query</em> and this will advance it to the end
+              beginning of |query| and this will advance it to the end
               of the query to search for a potential suffix. Otherwise, this
               will find the next instance of query.
             </div>
-        3. If <em>search position</em> is null, then break.
-        4. Let <em>potential match position</em> be a
-            <a spec=infra for=string>position variable</a> equal to <em>search
-            position</em> minus the length of <em>query</em>.
-        5. If <em>suffix</em> is the empty string, then return <em>potential
-            match position</em>.
-        6. <a spec=infra>Skip ASCII whitespace</a> on <em>search position</em>.
-        7. If <em>search position</em> is at the end of <em>text</em>, then:
-            1. Let <em>suffix_walker</em> be a {{TreeWalker}} that is a copy of
-                <em>walker</em>.
-            2. Perform [[#advance-walker-to-text]] on <em>suffix_walker</em>.
+        3. If |search position| is null, then break.
+        4. Let |potential match position| be a
+            <a spec=infra for=string>position variable</a> equal to |search
+            position| minus the length of |query|.
+        5. If |suffix| is the empty string, then return |potential
+            match position|.
+        6. <a spec=infra>Skip ASCII whitespace</a> on |search position|.
+        7. If |search position| is at the end of |text|, then:
+            1. Let |suffix_walker| be a {{TreeWalker}} that is a copy of
+                |walker|.
+            2. Perform [[#advance-walker-to-text]] on |suffix_walker|.
             3. If <em>suffix_walker.currentNode</em> is null, then return null.
-            4. Set <em>text</em> to
+            4. Set |text| to
                 <em>suffix_walker.currentNode.innerText</em>.
-            5. Set <em>search position</em> to the beginning of <em>text</em>.
-            6. <a spec=infra>Skip ASCII whitespace</a> on <em>search
-                position</em>.
-        8. If the result of [[#next-word-bounded-instance]] of <em>suffix</em>
-            in <em>text</em> from <em>search position</em> with [=current
-            locale=] starts at <em>search position</em>, then return
-            <em>potential match position</em>.
-    4. Perform [[#advance-walker-to-text]] on <em>walker</em>.
+            5. Set |search position| to the beginning of |text|.
+            6. <a spec=infra>Skip ASCII whitespace</a> on |search
+                position|.
+        8. If the result of [[#next-word-bounded-instance]] of |suffix|
+            in |text| from |search position| with [=current
+            locale=] starts at |search position|, then return
+            |potential match position|.
+    4. Perform [[#advance-walker-to-text]] on |walker|.
 2. Return null.
 
 The <dfn>current locale</dfn> is the <a spec=html>language</a> of the
-<em>currentNode</em>.
+|currentNode|.
 
 ### Advance a TreeWalker to the next text node ### {#advance-walker-to-text}
 <div class="note">

--- a/index.bs
+++ b/index.bs
@@ -623,7 +623,7 @@ these steps:
    then return null.
 1. Let |parsed values| be the result of running
    [[#parse-a-text-directive]] on |directive|.
-1. If <em>parsed values</em> is null, return null.
+1. If |parsed values| is null, return null.
 1. Let |prefix|, |textStart|, |textEnd|, and |suffix| be the values of the
    equivalent items in |parsed values|.
 1. Let |walker| be a {{TreeWalker}} equal to

--- a/index.html
+++ b/index.html
@@ -1470,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-18">18 February 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-19">19 February 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1509,59 +1509,61 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <nav data-fill-with="table-of-contents" id="toc">
    <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
    <ol class="toc" role="directory">
+    <li><a href="#infrastructure"><span class="secno">1</span> <span class="content">Infrastructure</span></a>
     <li>
-     <a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+     <a href="#introduction"><span class="secno">2</span> <span class="content">Introduction</span></a>
      <ol class="toc">
       <li>
-       <a href="#use-cases"><span class="secno">1.1</span> <span class="content">Use cases</span></a>
+       <a href="#use-cases"><span class="secno">2.1</span> <span class="content">Use cases</span></a>
        <ol class="toc">
-        <li><a href="#web-text-references"><span class="secno">1.1.1</span> <span class="content">Web text references</span></a>
-        <li><a href="#user-sharing"><span class="secno">1.1.2</span> <span class="content">User sharing</span></a>
+        <li><a href="#web-text-references"><span class="secno">2.1.1</span> <span class="content">Web text references</span></a>
+        <li><a href="#user-sharing"><span class="secno">2.1.2</span> <span class="content">User sharing</span></a>
        </ol>
      </ol>
     <li>
-     <a href="#description"><span class="secno">2</span> <span class="content">Description</span></a>
+     <a href="#description"><span class="secno">3</span> <span class="content">Description</span></a>
      <ol class="toc">
-      <li><a href="#indication"><span class="secno">2.1</span> <span class="content">Indication</span></a>
+      <li><a href="#indication"><span class="secno">3.1</span> <span class="content">Indication</span></a>
       <li>
-       <a href="#syntax"><span class="secno">2.2</span> <span class="content">Syntax</span></a>
+       <a href="#syntax"><span class="secno">3.2</span> <span class="content">Syntax</span></a>
        <ol class="toc">
-        <li><a href="#context-terms"><span class="secno">2.2.1</span> <span class="content">Context Terms</span></a>
+        <li><a href="#context-terms"><span class="secno">3.2.1</span> <span class="content">Context Terms</span></a>
        </ol>
       <li>
-       <a href="#the-fragment-directive"><span class="secno">2.3</span> <span class="content">The Fragment Directive</span></a>
+       <a href="#the-fragment-directive"><span class="secno">3.3</span> <span class="content">The Fragment Directive</span></a>
        <ol class="toc">
-        <li><a href="#parsing-the-fragment-directive"><span class="secno">2.3.1</span> <span class="content">Parsing the fragment directive</span></a>
-        <li><a href="#fragment-directive-grammar"><span class="secno">2.3.2</span> <span class="content">Fragment directive grammar</span></a>
+        <li><a href="#parsing-the-fragment-directive"><span class="secno">3.3.1</span> <span class="content">Parsing the fragment directive</span></a>
+        <li><a href="#fragment-directive-grammar"><span class="secno">3.3.2</span> <span class="content">Fragment directive grammar</span></a>
        </ol>
       <li>
-       <a href="#security-and-privacy"><span class="secno">2.4</span> <span class="content">Security and Privacy</span></a>
+       <a href="#security-and-privacy"><span class="secno">3.4</span> <span class="content">Security and Privacy</span></a>
        <ol class="toc">
-        <li><a href="#motivation"><span class="secno">2.4.1</span> <span class="content">Motivation</span></a>
-        <li><a href="#scroll-on-navigation"><span class="secno">2.4.2</span> <span class="content">Scroll On Navigation</span></a>
-        <li><a href="#search-timing"><span class="secno">2.4.3</span> <span class="content">Search Timing</span></a>
-        <li><a href="#should-allow-text-fragment"><span class="secno">2.4.4</span> <span class="content">Should Allow Text Fragment</span></a>
-        <li><a href="#allow-text-fragment-directive-flag"><span class="secno">2.4.5</span> <span class="content">allowTextFragmentDirective flag</span></a>
+        <li><a href="#motivation"><span class="secno">3.4.1</span> <span class="content">Motivation</span></a>
+        <li><a href="#scroll-on-navigation"><span class="secno">3.4.2</span> <span class="content">Scroll On Navigation</span></a>
+        <li><a href="#search-timing"><span class="secno">3.4.3</span> <span class="content">Search Timing</span></a>
+        <li><a href="#should-allow-text-fragment"><span class="secno">3.4.4</span> <span class="content">Should Allow Text Fragment</span></a>
+        <li><a href="#allow-text-fragment-directive-flag"><span class="secno">3.4.5</span> <span class="content">allowTextFragmentDirective flag</span></a>
        </ol>
       <li>
-       <a href="#navigating-to-text-fragment"><span class="secno">2.5</span> <span class="content">Navigating to a Text Fragment</span></a>
+       <a href="#navigating-to-text-fragment"><span class="secno">3.5</span> <span class="content">Navigating to a Text Fragment</span></a>
        <ol class="toc">
-        <li><a href="#scroll-rect-into-view"><span class="secno">2.5.1</span> <span class="content">Scroll a DOMRect into view</span></a>
-        <li><a href="#find-text-matches"><span class="secno">2.5.2</span> <span class="content">Find text matches</span></a>
-        <li><a href="#find-a-target-text"><span class="secno">2.5.3</span> <span class="content">Find a target text</span></a>
-        <li><a href="#find-match-with-context"><span class="secno">2.5.4</span> <span class="content">Find an exact match with context</span></a>
-        <li><a href="#advance-walker-to-text"><span class="secno">2.5.5</span> <span class="content">Advance a TreeWalker to the next text node</span></a>
-        <li><a href="#next-word-bounded-instance"><span class="secno">2.5.6</span> <span class="content">Find the next word bounded instance</span></a>
+        <li><a href="#scroll-rect-into-view"><span class="secno">3.5.1</span> <span class="content">Scroll a DOMRect into view</span></a>
+        <li><a href="#find-text-matches"><span class="secno">3.5.2</span> <span class="content">Find text matches</span></a>
+        <li><a href="#parse-a-text-directive"><span class="secno">3.5.3</span> <span class="content">Parse a text directive</span></a>
+        <li><a href="#find-a-matching-range"><span class="secno">3.5.4</span> <span class="content">Find a matching Range</span></a>
+        <li><a href="#find-match-with-context"><span class="secno">3.5.5</span> <span class="content">Find an exact match with context</span></a>
+        <li><a href="#advance-walker-to-text"><span class="secno">3.5.6</span> <span class="content">Advance a TreeWalker to the next text node</span></a>
+        <li><a href="#next-word-bounded-instance"><span class="secno">3.5.7</span> <span class="content">Find the next word bounded instance</span></a>
        </ol>
-      <li><a href="#indicating-the-text-match"><span class="secno">2.6</span> <span class="content">Indicating The Text Match</span></a>
-      <li><a href="#feature-detectability"><span class="secno">2.7</span> <span class="content">Feature Detectability</span></a>
+      <li><a href="#indicating-the-text-match"><span class="secno">3.6</span> <span class="content">Indicating The Text Match</span></a>
+      <li><a href="#feature-detectability"><span class="secno">3.7</span> <span class="content">Feature Detectability</span></a>
      </ol>
     <li>
-     <a href="#generating-text-fragment-directives"><span class="secno">3</span> <span class="content">Generating Text Fragment Directives</span></a>
+     <a href="#generating-text-fragment-directives"><span class="secno">4</span> <span class="content">Generating Text Fragment Directives</span></a>
      <ol class="toc">
-      <li><a href="#prefer-exact-matching-to-range-based"><span class="secno">3.1</span> <span class="content">Prefer Exact Matching To Range-based</span></a>
-      <li><a href="#use-context-only-when-necessary"><span class="secno">3.2</span> <span class="content">Use Context Only When Necessary</span></a>
-      <li><a href="#determine-if-fragment-id-is-needed"><span class="secno">3.3</span> <span class="content">Determine If Fragment Id Is Needed</span></a>
+      <li><a href="#prefer-exact-matching-to-range-based"><span class="secno">4.1</span> <span class="content">Prefer Exact Matching To Range-based</span></a>
+      <li><a href="#use-context-only-when-necessary"><span class="secno">4.2</span> <span class="content">Use Context Only When Necessary</span></a>
+      <li><a href="#determine-if-fragment-id-is-needed"><span class="secno">4.3</span> <span class="content">Determine If Fragment Id Is Needed</span></a>
      </ol>
     <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
     <li>
@@ -1579,16 +1581,18 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    </ol>
   </nav>
   <main>
-   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <h2 class="heading settled" data-level="1" id="infrastructure"><span class="secno">1. </span><span class="content">Infrastructure</span><a class="self-link" href="#infrastructure"></a></h2>
+   <p>This specification depends on the Infra Standard. <a data-link-type="biblio" href="#biblio-infra">[INFRA]</a> </p>
+   <h2 class="heading settled" data-level="2" id="introduction"><span class="secno">2. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
    <div class="note" role="note">This section is non-normative</div>
-   <h3 class="heading settled" data-level="1.1" id="use-cases"><span class="secno">1.1. </span><span class="content">Use cases</span><a class="self-link" href="#use-cases"></a></h3>
-   <h4 class="heading settled" data-level="1.1.1" id="web-text-references"><span class="secno">1.1.1. </span><span class="content">Web text references</span><a class="self-link" href="#web-text-references"></a></h4>
+   <h3 class="heading settled" data-level="2.1" id="use-cases"><span class="secno">2.1. </span><span class="content">Use cases</span><a class="self-link" href="#use-cases"></a></h3>
+   <h4 class="heading settled" data-level="2.1.1" id="web-text-references"><span class="secno">2.1.1. </span><span class="content">Web text references</span><a class="self-link" href="#web-text-references"></a></h4>
     The core use case for text fragments is to allow URLs to serve as an exact text
 reference across the web. For example, Wikipedia references could link to the
 exact text they are quoting from a page. Similarly, search engines can serve
 URLs that direct the user to the answer they are looking for in the page rather
 than linking to the top of the page. 
-   <h4 class="heading settled" data-level="1.1.2" id="user-sharing"><span class="secno">1.1.2. </span><span class="content">User sharing</span><a class="self-link" href="#user-sharing"></a></h4>
+   <h4 class="heading settled" data-level="2.1.2" id="user-sharing"><span class="secno">2.1.2. </span><span class="content">User sharing</span><a class="self-link" href="#user-sharing"></a></h4>
     With text fragments, browsers may implement an option to 'Copy URL to here'
 when the user opens the context menu on a text selection. The browser can then
 generate a URL with the text selection appropriately specified, and the
@@ -1596,8 +1600,8 @@ recipient of the URL will have the specified text conveniently indicated.
 Without text fragments, if a user wants to share a passage of text from a page,
 they would likely just copy and paste the passage, in which case the receiver
 loses the context of the page. 
-   <h2 class="heading settled" data-level="2" id="description"><span class="secno">2. </span><span class="content">Description</span><a class="self-link" href="#description"></a></h2>
-   <h3 class="heading settled" data-level="2.1" id="indication"><span class="secno">2.1. </span><span class="content">Indication</span><a class="self-link" href="#indication"></a></h3>
+   <h2 class="heading settled" data-level="3" id="description"><span class="secno">3. </span><span class="content">Description</span><a class="self-link" href="#description"></a></h2>
+   <h3 class="heading settled" data-level="3.1" id="indication"><span class="secno">3.1. </span><span class="content">Indication</span><a class="self-link" href="#indication"></a></h3>
    <div class="note" role="note">This section is non-normative</div>
    <p>This specification intentionally doesn’t define what actions a user agent
 should or could take to "indicate" a text match. There are different
@@ -1616,10 +1620,10 @@ actions:</p>
      <p>Providing a notification when the text passage isn’t found in the page</p>
    </ul>
    <div class="note" role="note"> The choice of action can have implications for user security and privacy.  See
-the <a href="#security-and-privacy">§ 2.4 Security and Privacy</a> section for details. </div>
-   <h3 class="heading settled" data-level="2.2" id="syntax"><span class="secno">2.2. </span><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
+the <a href="#security-and-privacy">§ 3.4 Security and Privacy</a> section for details. </div>
+   <h3 class="heading settled" data-level="3.2" id="syntax"><span class="secno">3.2. </span><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
    <div class="note" role="note">This section is non-normative</div>
-   <p>A <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive">text fragment directive</a> is specified in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive">fragment directive</a> (see <a href="#the-fragment-directive">§ 2.3 The Fragment Directive</a>) with the following format:</p>
+   <p>A <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive">text fragment directive</a> is specified in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive">fragment directive</a> (see <a href="#the-fragment-directive">§ 3.3 The Fragment Directive</a>) with the following format:</p>
 <pre>#:~:text=[prefix-,]textStart[,textEnd][,-suffix]
           context  |-------match-----|  context
 </pre>
@@ -1640,7 +1644,7 @@ long text directive.</p>
    <div class="example" id="example-7df2027e"><a class="self-link" href="#example-7df2027e"></a> <code>#:~:text=an%20example,text%20fragment</code> indicates that the first
 instance of "an example" until the following first instance of "text fragment"
 is the target text. </div>
-   <h4 class="heading settled" data-level="2.2.1" id="context-terms"><span class="secno">2.2.1. </span><span class="content">Context Terms</span><a class="self-link" href="#context-terms"></a></h4>
+   <h4 class="heading settled" data-level="3.2.1" id="context-terms"><span class="secno">3.2.1. </span><span class="content">Context Terms</span><a class="self-link" href="#context-terms"></a></h4>
    <div class="note" role="note">This section is non-normative</div>
    <p>The other two optional parameters are context terms. They are specified by the
 dash (-) character succeeding the prefix and preceding the suffix, to
@@ -1659,7 +1663,7 @@ visually indicated.</p>
    <div class="example" id="example-5c87b699"><a class="self-link" href="#example-5c87b699"></a> <code>#:~:text=this%20is-,an%20example,-text%20fragment</code> would match
 to "an example" in "this is an example text fragment", but not match to "an
 example" in "here is an example text". </div>
-   <h3 class="heading settled" data-level="2.3" id="the-fragment-directive"><span class="secno">2.3. </span><span class="content">The Fragment Directive</span><a class="self-link" href="#the-fragment-directive"></a></h3>
+   <h3 class="heading settled" data-level="3.3" id="the-fragment-directive"><span class="secno">3.3. </span><span class="content">The Fragment Directive</span><a class="self-link" href="#the-fragment-directive"></a></h3>
     To avoid compatibility issues with usage of existing URL fragments, this spec
 introduces the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①">fragment directive</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive②">fragment directive</a> is a portion
 of the URL fragment delimited by the code sequence <code>:~:</code>. It is
@@ -1670,7 +1674,7 @@ for the UA rather than the document. It’s meant to avoid direct interaction wi
 author script so that future UA instructions can be added without fear of
 introducing breaking changes to existing content. Potential examples could be:
 translation-hints or enabling accessibility features.</p>
-   <h4 class="heading settled" data-level="2.3.1" id="parsing-the-fragment-directive"><span class="secno">2.3.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
+   <h4 class="heading settled" data-level="3.3.1" id="parsing-the-fragment-directive"><span class="secno">3.3.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
    <p>To the definition of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>, add:</p>
    <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is either
 null or an ASCII string holding data used by the UA to process the resource. It
@@ -1728,7 +1732,7 @@ web-exposed)</p>
    <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
 the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> is the string
 "text=foo". </div>
-   <h4 class="heading settled" data-level="2.3.2" id="fragment-directive-grammar"><span class="secno">2.3.2. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
+   <h4 class="heading settled" data-level="3.3.2" id="fragment-directive-grammar"><span class="secno">3.3.2. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
     A <dfn data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive<a class="self-link" href="#valid-fragment-directive"></a></dfn> is a sequence of characters that appears
 in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a> that matches the production: 
    <dl> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirective">FragmentDirective</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> | <a data-link-type="dfn" href="#unknowndirective" id="ref-for-unknowndirective">UnknownDirective</a>) ("&amp;" <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective">FragmentDirective</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="unknowndirective">UnknownDirective</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#characterstring" id="ref-for-characterstring">CharacterString</a></dd></code> </dl>
@@ -1769,8 +1773,8 @@ is not explicitly used in the <a data-link-type="dfn" href="#textdirective" id="
 ",", which must be percent-encoded. </div>
      <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar">PercentEncodedChar</dfn> ::=</dt><dd>"%" [a-zA-Z0-9]+</dd></code> 
    </dl>
-   <h3 class="heading settled" data-level="2.4" id="security-and-privacy"><span class="secno">2.4. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-and-privacy"></a></h3>
-   <h4 class="heading settled" data-level="2.4.1" id="motivation"><span class="secno">2.4.1. </span><span class="content">Motivation</span><a class="self-link" href="#motivation"></a></h4>
+   <h3 class="heading settled" data-level="3.4" id="security-and-privacy"><span class="secno">3.4. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-and-privacy"></a></h3>
+   <h4 class="heading settled" data-level="3.4.1" id="motivation"><span class="secno">3.4.1. </span><span class="content">Motivation</span><a class="self-link" href="#motivation"></a></h4>
    <div class="note" role="note">This section is non-normative</div>
    <p>Care must be taken when implementing <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive①">text fragment directive</a> so that it
 cannot be used to exfiltrate information across origins. Scripts can navigate a
@@ -1798,7 +1802,7 @@ vectors. In summary, the text fragment directives are invoked only on full
 Additionally, navigations originating from a different origin than the
 destination will require the navigation to take place in a "noopener" context,
 such that the destination page is known to be sufficiently isolated.</p>
-   <h4 class="heading settled" data-level="2.4.2" id="scroll-on-navigation"><span class="secno">2.4.2. </span><span class="content">Scroll On Navigation</span><a class="self-link" href="#scroll-on-navigation"></a></h4>
+   <h4 class="heading settled" data-level="3.4.2" id="scroll-on-navigation"><span class="secno">3.4.2. </span><span class="content">Scroll On Navigation</span><a class="self-link" href="#scroll-on-navigation"></a></h4>
    <p>A UA may choose to automatically scroll a matched text passage into view. This
 can be a convenient experience for the user but does present some risks that
 implementing UAs should be aware of.</p>
@@ -1827,21 +1831,21 @@ navigating to a text fragment.</p>
 may, instead, provide UI to initiate the scroll ("click to scroll") or none
 at all. In these cases UA should provide some indication to the user that an
 indicated passage exists further down on the page.</p>
-   <h4 class="heading settled" data-level="2.4.3" id="search-timing"><span class="secno">2.4.3. </span><span class="content">Search Timing</span><a class="self-link" href="#search-timing"></a></h4>
+   <h4 class="heading settled" data-level="3.4.3" id="search-timing"><span class="secno">3.4.3. </span><span class="content">Search Timing</span><a class="self-link" href="#search-timing"></a></h4>
    <p>A naive implementation of the text search algorithm could allow information
 exfiltration based on runtime duration differences between a matching and non-
 matching query. If an attacker were to find a way to synchronously navigate
 to a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑤">text fragment directive</a>-invoking URL, they would be able to determine
 the existence of a text snippet by measuring how long the navigation call takes.</p>
-   <div class="note" role="note"> The restrictions in <a href="#should-allow-text-fragment">§ 2.4.4 Should Allow Text Fragment</a> should prevent this
+   <div class="note" role="note"> The restrictions in <a href="#should-allow-text-fragment">§ 3.4.4 Should Allow Text Fragment</a> should prevent this
   specific case; in particular, the no-same-document-navigation restriction.
   However, these restrictions are provided as multiple layers of defence. </div>
-   <p>For this reason, the implementation <em>must ensure the runtime of <a href="#navigating-to-text-fragment">§ 2.5 Navigating to a Text Fragment</a> steps does not differ based on whether a match
+   <p>For this reason, the implementation <em>must ensure the runtime of <a href="#navigating-to-text-fragment">§ 3.5 Navigating to a Text Fragment</a> steps does not differ based on whether a match
 has been successfully found</em>.</p>
    <p>This specification does not specify exactly how a UA achieves this as there are
-multiple solutions with differing tradeoffs. For example, a UA <em>may</em> continue to walk the tree even after a match is found in <a href="#find-a-target-text">§ 2.5.3 Find a target text</a>.  Alternatively, it <em>may</em> schedule an
+multiple solutions with differing tradeoffs. For example, a UA <em>may</em> continue to walk the tree even after a match is found in <a href="#find-a-matching-range">§ 3.5.4 Find a matching Range</a>.  Alternatively, it <em>may</em> schedule an
 asynchronous task to find and set the indicated part of the document.</p>
-   <h4 class="heading settled" data-level="2.4.4" id="should-allow-text-fragment"><span class="secno">2.4.4. </span><span class="content">Should Allow Text Fragment</span><a class="self-link" href="#should-allow-text-fragment"></a></h4>
+   <h4 class="heading settled" data-level="3.4.4" id="should-allow-text-fragment"><span class="secno">3.4.4. </span><span class="content">Should Allow Text Fragment</span><a class="self-link" href="#should-allow-text-fragment"></a></h4>
    <div class="note" role="note"> TODO: This should really only prevent potentially observable side-effects like
   automatic scrolling. Unobservable effects like a highlight should be safely
   allowed in all cases. </div>
@@ -1867,7 +1871,7 @@ return false.</p>
     <li data-md>
      <p>Otherwise, return false.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.4.5" id="allow-text-fragment-directive-flag"><span class="secno">2.4.5. </span><span class="content">allowTextFragmentDirective flag</span><a class="self-link" href="#allow-text-fragment-directive-flag"></a></h4>
+   <h4 class="heading settled" data-level="3.4.5" id="allow-text-fragment-directive-flag"><span class="secno">3.4.5. </span><span class="content">allowTextFragmentDirective flag</span><a class="self-link" href="#allow-text-fragment-directive-flag"></a></h4>
    <div class="note" role="note"> The algorithm to determine whether or not a text fragment directive should be
   allowed to invoke must be run during document navigation and creation and
   stored as a flag since it relies on the properties of the navigation while
@@ -1881,7 +1885,7 @@ these steps after step 1:</p>
    by user activation</a></p>
     <li data-md>
      <p>Set <em>document</em>’s <em>allowTextFragmentDirective</em> flag to the
-   result of running <a href="#should-allow-text-fragment">§ 2.4.4 Should Allow Text Fragment</a> with <em>is user
+   result of running <a href="#should-allow-text-fragment">§ 3.4.4 Should Allow Text Fragment</a> with <em>is user
    activated</em>, <em>incumbentNavigationOrigin</em>, and <em>document</em>.</p>
    </ol>
    <p>Amend the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment">try to scroll to the fragment</a> steps by replacing the steps of the task queued in step 2:</p>
@@ -1897,7 +1901,7 @@ these steps after step 1:</p>
     <li data-md>
      <p>Clear <em>document</em>’s <em>allowTextFragmentDirective</em> flag</p>
    </ol>
-   <h3 class="heading settled" data-level="2.5" id="navigating-to-text-fragment"><span class="secno">2.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
+   <h3 class="heading settled" data-level="3.5" id="navigating-to-text-fragment"><span class="secno">3.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
    <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.8.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑦">text fragment directive</a> is
 present and a match is found in the page, the text fragment takes precedent over
 the element fragment as the indicated part of the document. We amend the
@@ -1942,10 +1946,10 @@ into view</a>, with <em>behavior</em> set to "auto", <em>block</em> set to "star
      <p>Let <em>fragment directive string</em> be the <em>document</em>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment
 directive</a>.</p>
     <li data-md>
-     <p>If <em>document</em>’s <a href="#allow-text-fragment-directive-flag">§ 2.4.5 allowTextFragmentDirective flag</a> is true then:</p>
+     <p>If <em>document</em>’s <a href="#allow-text-fragment-directive-flag">§ 3.4.5 allowTextFragmentDirective flag</a> is true then:</p>
      <ol>
       <li data-md>
-       <p>Let <em>ranges</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> that is the result of <a href="#find-text-matches">§ 2.5.2 Find text matches</a> with <em>fragment directive string</em>.</p>
+       <p>Let <em>ranges</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> that is the result of <a href="#find-text-matches">§ 3.5.2 Find text matches</a> with <em>fragment directive string</em>.</p>
       <li data-md>
        <p>If <em>ranges</em> is non-empty, then:</p>
        <ol>
@@ -1968,7 +1972,7 @@ is not revealed to script, which is left as UA-defined behavior. </div>
        </ol>
      </ol>
    </ol>
-   <h4 class="heading settled" data-level="2.5.1" id="scroll-rect-into-view"><span class="secno">2.5.1. </span><span class="content">Scroll a DOMRect into view</span><a class="self-link" href="#scroll-rect-into-view"></a></h4>
+   <h4 class="heading settled" data-level="3.5.1" id="scroll-rect-into-view"><span class="secno">3.5.1. </span><span class="content">Scroll a DOMRect into view</span><a class="self-link" href="#scroll-rect-into-view"></a></h4>
    <div class="note" role="note"> This section describes a refactoring of the CSSOMVIEW’s <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view①">scroll an element into view</a> algorithm 
   to separate the steps for scrolling a DOMRect into view, so it can be used to
   scroll a Range into view. </div>
@@ -1992,10 +1996,10 @@ box</em> with options <em>options</em> and startingElement <em>element</em>.</p>
     <li data-md>
      <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view③">scroll a DOMRect into view</a> on <em>bounding rect</em> with <em>options</em> and startingElement <em>containingElement</em>.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.5.2" id="find-text-matches"><span class="secno">2.5.2. </span><span class="content">Find text matches</span><a class="self-link" href="#find-text-matches"></a></h4>
+   <h4 class="heading settled" data-level="3.5.2" id="find-text-matches"><span class="secno">3.5.2. </span><span class="content">Find text matches</span><a class="self-link" href="#find-text-matches"></a></h4>
    <div class="note" role="note"> This algorithm has input <em>fragment directive input</em>, that is the raw
-fragment directive <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑤">Range</a></code>s that are to be visually indicated, and the first should be
-scrolled into view. </div>
+  fragment directive <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑤">Range</a></code>s that are to be visually indicated, the
+  first of which should be scrolled into view. </div>
    <ol>
     <li data-md>
      <p>If <em>fragment directive input</em> does not match the <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective③">FragmentDirective</a> production, then return an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>.</p>
@@ -2012,106 +2016,124 @@ initially empty.</p>
        <p>If <em>directive</em> does not match the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a>,
 then continue.</p>
       <li data-md>
-       <p>If the result of <a href="#find-a-target-text">§ 2.5.3 Find a target text</a> on <em>directive</em> is
+       <p>If the result of <a href="#find-a-matching-range">§ 3.5.4 Find a matching Range</a> on <em>directive</em> is
 non-null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> it to <em>ranges</em>.</p>
      </ol>
     <li data-md>
      <p>Return <em>ranges</em>.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.5.3" id="find-a-target-text"><span class="secno">2.5.3. </span><span class="content">Find a target text</span><a class="self-link" href="#find-a-target-text"></a></h4>
-   <p>To find the target text for a given <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> <em>text
-directive input</em>, the user agent must run these steps:</p>
+   <h4 class="heading settled" data-level="3.5.3" id="parse-a-text-directive"><span class="secno">3.5.3. </span><span class="content">Parse a text directive</span><a class="self-link" href="#parse-a-text-directive"></a></h4>
+   <div class="note" role="note">
+    <p> This algorithm takes a single text directive string as input (e.g.
+    "text=prefix-,foo,bar") and attempts to parse the string into the
+    components of the directive (e.g. "prefix", "foo", "bar"). See <a href="#syntax">§ 3.2 Syntax</a> for the what each of these components means and how they’re used. </p>
+    <p> Returns null if the input is invalid or fails to parse in any way.
+    Otherwise, returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct">struct</a> containing four strings: <em>textStart</em>, <em>textEnd</em>, <em>prefix</em>, <em>suffix</em>.
+    Only <em>textStart</em> is required to be non-null as the other parameters
+    are optional and may be omitted in a valid text directive string. </p>
+   </div>
    <ol>
     <li data-md>
-     <p>If <em>text directive input</em> does not begin with the string "text=",
-then return null.</p>
-    <li data-md>
-     <p>Let <em>raw target text</em> be the substring of <em>text directive
-input</em> starting at index 5.</p>
+     <p>Let <var>raw target text</var> be the substring of <em>text directive
+   input</em> starting at index 5.</p>
      <div class="note" role="note"> This is the remainder of the <em>text directive input</em> following,
-but not including, the "text=" prefix. </div>
+ but not including, the "text=" prefix. </div>
     <li data-md>
-     <p>If <em>raw target text</em> is the empty string, return null.</p>
+     <p>Let <var>tokens</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of strings that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <var>raw target text</var> on commas</a>.</p>
     <li data-md>
-     <p>Let <em>tokens</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a>s that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <em>raw target text</em> on
-commas</a>.</p>
+     <p>If <var>tokens</var> has size less than 1 or greater than 4, return null.</p>
     <li data-md>
-     <p>Let <em>prefix</em> and <em>suffix</em> and <em>textEnd</em> be the empty
-string.</p>
-     <div class="note" role="note"> prefix, suffix, and textEnd are the optional parameters of the text
-  directive. </div>
+     <p>If any of <var>tokens</var>’ items are the empty string, return null.</p>
     <li data-md>
-     <p>Let <em>potential prefix</em> be the first item of <em>tokens</em>.</p>
+     <p>Let <var>retVal</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct①">struct</a> consisting of four strings: <em>textStart</em>, <em>textEnd</em>, <em>prefix</em> and <em>suffix</em>, each initialized to null.</p>
+    <li data-md>
+     <p>Let <var>potential prefix</var> be the first item of <var>tokens</var>.</p>
     <li data-md>
      <p>If the last character of <em>potential prefix</em> is U+002D (-), then:</p>
-     <ol>
-      <li data-md>
-       <p>Set <em>prefix</em> to the result of removing the last character from <em>potential prefix</em>.</p>
-      <li data-md>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> the first item of <em>tokens</em>.</p>
-     </ol>
     <li data-md>
-     <p>Let <em>potential suffix</em> be the last item from <em>tokens</em>.</p>
+     <p>Set <em>retVal.prefix</em> to the result of removing the last character from <em>potential prefix</em>.</p>
+    <li data-md>
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> the first item of the list <var>tokens</var>.</p>
+    <li data-md>
+     <p>Let <em>potential suffix</em> be the last item of <var>tokens</var>, if one exists.</p>
     <li data-md>
      <p>If the first character of <em>potential suffix</em> is U+002D (-), then:</p>
      <ol>
       <li data-md>
-       <p>Set <em>suffix</em> to the result of removing the first character from <em>potential suffix</em>.</p>
+       <p>Set <em>retVal.suffix</em> to the result of removing the first character from <em>potential suffix</em>.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove①">Remove</a> the last item from <em>tokens</em>.</p>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove①">Remove</a> the last item of the list <var>tokens</var>.</p>
      </ol>
     <li data-md>
-     <p class="assertion">Assert: <em>tokens</em> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> 1 or <em>tokens</em> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size①">size</a> 2.</p>
-     <div class="note" role="note"> Once the prefix and suffix are removed from tokens, tokens may either
-contain one item (textStart) or two items (textStart and textEnd). </div>
+     <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> not equal to 1 nor 2 then
+   return null.</p>
     <li data-md>
-     <p>Let <em>textStart</em> be the first item of <em>tokens</em>.</p>
+     <p>Let <em>retVal.textStart</em> be the first item of <var>tokens</var>.</p>
     <li data-md>
-     <p>If <em>tokens</em> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size②">size</a> 2, then let <em>textEnd</em> be the last item of <em>tokens</em>.</p>
-     <div class="note" role="note"> The strings prefix, textStart, textEnd, and suffix now contain the
-text directive parameters as defined in <a href="#syntax">§ 2.2 Syntax</a>. </div>
+     <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size①">size</a> 2, then let <em>retVal.textEnd</em> be the last item of <var>tokens</var>.</p>
     <li data-md>
-     <p>Let <em>walker</em> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker">TreeWalker</a></code> equal to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createtreewalker" id="ref-for-dom-document-createtreewalker">createTreeWalker()</a></code>.</p>
+     <p>Return <var>retVal</var></p>
+   </ol>
+   <h4 class="heading settled" data-level="3.5.4" id="find-a-matching-range"><span class="secno">3.5.4. </span><span class="content">Find a matching Range</span><a class="self-link" href="#find-a-matching-range"></a></h4>
+   <div class="note" role="note">
+    <p> This algorithm takes a single <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> <var>directive</var> as
+    input (e.g.  "text=prefix-,foo,bar") and returns the first <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑦">Range</a></code> in the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> that corresponds to the match string(s) in the text directive
+    and satisfies the prefix and suffix (if given).  Returns null if no such <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑧">Range</a></code> exists. </p>
+   </div>
+   <p>To find the target text for a given string <var>directive</var>, the user agent must run
+these steps:</p>
+   <ol>
     <li data-md>
-     <p>Let <em>position</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable①">position variable</a> that indicates a text offset in <em>walker.currentNode.innerText</em>.</p>
+     <p>If <var>directive</var> does not begin with the string "text=",
+   then return null.</p>
     <li data-md>
-     <p>If textEnd is the empty string, then:</p>
+     <p>Let <var>parsed values</var> be the result of running <a href="#parse-a-text-directive">§ 3.5.3 Parse a text directive</a> on <var>directive</var>.</p>
+    <li data-md>
+     <p>If <em>parsed values</em> is null, return null.</p>
+    <li data-md>
+     <p>Let <var>prefix</var>, <var>textStart</var>, <var>textEnd</var>, and <var>suffix</var> be the values of the
+   equivalent items in <var>parsed values</var>.</p>
+    <li data-md>
+     <p>Let <var>walker</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker">TreeWalker</a></code> equal to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createtreewalker" id="ref-for-dom-document-createtreewalker">document.createTreeWalker()</a></code>.</p>
+    <li data-md>
+     <p>Let <var>position</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable①">position variable</a> that indicates a text offset in <em>walker.currentNode.innerText</em>.</p>
+    <li data-md>
+     <p>If <var>textEnd</var> is the empty string, then:</p>
      <ol>
       <li data-md>
-       <p>Let <em>match position</em> be the result of <a href="#find-match-with-context">§ 2.5.4 Find an exact match with context</a> with input walker <em>walker</em>, search position <em>position</em>,
-prefix <em>prefix</em>, query <em>textStart</em>, and suffix <em>suffix</em>.</p>
+       <p>Let <var>match position</var> be the result of <a href="#find-match-with-context">§ 3.5.5 Find an exact match with context</a> with input walker <var>walker</var>, search position <var>position</var>,
+prefix <var>prefix</var>, query <var>textStart</var>, and suffix <var>suffix</var>.</p>
       <li data-md>
-       <p>If <em>match position</em> is null, then return null.</p>
+       <p>If <var>match position</var> is null, return null.</p>
       <li data-md>
-       <p>Let <em>match</em> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑦">Range</a></code> in <em>walker.currentNode</em> with
-position <em>match position</em> and length equal to the length of <em>textStart</em>.</p>
+       <p>Let <var>match</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑨">Range</a></code> in <em>walker.currentNode</em> with
+position <var>match position</var> and length equal to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length">length</a> of <var>textStart</var>.</p>
       <li data-md>
-       <p>Return <em>match</em>.</p>
+       <p>Return <var>match</var>.</p>
      </ol>
     <li data-md>
-     <p>Otherwise, let <em>potential start position</em> be the result of <a href="#find-match-with-context">§ 2.5.4 Find an exact match with context</a> with input walker <em>walker</em>, start
-position <em>position</em>, prefix <em>prefix</em>, query <em>textStart</em>, and suffix <em>null</em>.</p>
+     <p>Otherwise, let <var>potential start position</var> be the result of <a href="#find-match-with-context">§ 3.5.5 Find an exact match with context</a> with input walker <var>walker</var>, start position <var>position</var>, prefix <var>prefix</var>, query <var>textStart</var>, and suffix <var>null</var>.</p>
     <li data-md>
-     <p>If <em>potential start position</em> is null, then return null.</p>
+     <p>If <var>potential start position</var> is null, then return null.</p>
     <li data-md>
-     <p>Let <em>end position</em> be the result of <a href="#find-match-with-context">§ 2.5.4 Find an exact match with context</a> with
-input walker <em>walker</em>, search position <em>potential start
-position</em>, prefix <em>null</em>, query <em>textEnd</em>, and suffix <em>suffix</em>.</p>
+     <p>Let <var>end position</var> be the result of <a href="#find-match-with-context">§ 3.5.5 Find an exact match with context</a> with input
+   walker <var>walker</var>, search position <var>potential start position</var>, prefix <var>null</var>,
+   query <var>textEnd</var>, and suffix <var>suffix</var>.</p>
     <li data-md>
-     <p>If <em>end position</em> is null, then return null.</p>
+     <p>If <var>end position</var> is null, then return null.</p>
     <li data-md>
-     <p>Advance <em>end position</em> by the length of <em>textEnd</em>.</p>
+     <p>Advance <var>end position</var> by the length of <var>textEnd</var>.</p>
     <li data-md>
-     <p>Let <em>match</em> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑧">Range</a></code> in <em>walker.currentNode</em> with start
-position <em>potential start position</em> and length equal to <em>end
-position - start position</em>.</p>
+     <p>Let <var>match</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①⓪">Range</a></code> in <em>walker.currentNode</em> with start
+   position <var>potential start position</var> and length equal to <var>end position</var> - <var>start
+   position</var>.</p>
     <li data-md>
-     <p>Return <em>match</em>.</p>
+     <p>Return <var>match</var>.</p>
    </ol>
-   <h4 class="heading settled" data-level="2.5.4" id="find-match-with-context"><span class="secno">2.5.4. </span><span class="content">Find an exact match with context</span><a class="self-link" href="#find-match-with-context"></a></h4>
-   <div class="note" role="note"> This algorithm has input <em>walker, search position, prefix, query,</em> and <em>suffix</em> and returns a text position that is the start of the match. </div>
-   <div class="note" role="note"> The input <em>walker</em> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker①">TreeWalker</a></code> reference, not a copy, i.e. any
-  modifications are performed on the caller’s instance of <em>walker</em>. </div>
+   <h4 class="heading settled" data-level="3.5.5" id="find-match-with-context"><span class="secno">3.5.5. </span><span class="content">Find an exact match with context</span><a class="self-link" href="#find-match-with-context"></a></h4>
+   <div class="note" role="note"> This algorithm has input <var>walker</var>, <var>search position</var>, <var>prefix</var>, <var>query</var>, and <var>suffix</var> and returns a text position that is the start of the match. </div>
+   <div class="note" role="note"> The input <var>walker</var> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker①">TreeWalker</a></code> reference, not a copy, i.e. any
+  modifications are performed on the caller’s instance of <var>walker</var>. </div>
    <ol>
     <li data-md>
      <p>While <em>walker.currentNode</em> is not null:</p>
@@ -2119,86 +2141,86 @@ position - start position</em>.</p>
       <li data-md>
        <p class="assertion">Assert: <em>walker.currentNode</em> is a text node.</p>
       <li data-md>
-       <p>Let <em>text</em> be equal to <em>walker.currentNode.innerText</em>.</p>
+       <p>Let <var>text</var> be equal to <em>walker.currentNode.innerText</em>.</p>
       <li data-md>
-       <p>While <em>search position</em> does not point past the end of <em>text</em>:</p>
+       <p>While <var>search position</var> does not point past the end of <var>text</var>:</p>
        <ol>
         <li data-md>
-         <p>If <em>prefix</em> is not the empty string, then:</p>
+         <p>If <var>prefix</var> is not the empty string, then:</p>
          <ol>
           <li data-md>
-           <p>Advance <em>search position</em> to the position after the result
-of <a href="#next-word-bounded-instance">§ 2.5.6 Find the next word bounded instance</a> of <em>prefix</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale">current
+           <p>Advance <var>search position</var> to the position after the result
+of <a href="#next-word-bounded-instance">§ 3.5.7 Find the next word bounded instance</a> of <var>prefix</var> in <var>text</var> from <var>search position</var> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale">current
 locale</a>.</p>
           <li data-md>
-           <p>If <em>search position</em> is null, then break.</p>
+           <p>If <var>search position</var> is null, then break.</p>
           <li data-md>
-           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace">Skip ASCII whitespace</a> on <em>search
-position</em>.</p>
+           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace">Skip ASCII whitespace</a> on <var>search
+position</var>.</p>
           <li data-md>
-           <p>If <em>search position</em> is at the end of <em>text</em>, then:</p>
+           <p>If <var>search position</var> is at the end of <var>text</var>, then:</p>
            <ol>
             <li data-md>
-             <p>Perform <a href="#advance-walker-to-text">§ 2.5.5 Advance a TreeWalker to the next text node</a> on <em>walker</em>.</p>
+             <p>Perform <a href="#advance-walker-to-text">§ 3.5.6 Advance a TreeWalker to the next text node</a> on <var>walker</var>.</p>
             <li data-md>
              <p>If <em>walker.currentNode</em> is null, then return null.</p>
             <li data-md>
-             <p>Set <em>text</em> to <em>walker.currentNode.innerText</em>.</p>
+             <p>Set <var>text</var> to <em>walker.currentNode.innerText</em>.</p>
             <li data-md>
-             <p>Set <em>search position</em> to the beginning of <em>text</em>.</p>
+             <p>Set <var>search position</var> to the beginning of <var>text</var>.</p>
             <li data-md>
-             <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace①">Skip ASCII whitespace</a> on <em>search
-position</em>.</p>
+             <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace①">Skip ASCII whitespace</a> on <var>search
+position</var>.</p>
            </ol>
           <li data-md>
-           <p>If the result of <a href="#next-word-bounded-instance">§ 2.5.6 Find the next word bounded instance</a> of <em>query</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale①">current locale</a> does not start at <em>search
-position</em>, then continue.</p>
+           <p>If the result of <a href="#next-word-bounded-instance">§ 3.5.7 Find the next word bounded instance</a> of <var>query</var> in <var>text</var> from <var>search position</var> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale①">current locale</a> does not start at <var>search
+position</var>, then continue.</p>
          </ol>
         <li data-md>
-         <p>Advance <em>search position</em> to the position after the result of <a href="#next-word-bounded-instance">§ 2.5.6 Find the next word bounded instance</a> of <em>query</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale②">current locale</a>.</p>
+         <p>Advance <var>search position</var> to the position after the result of <a href="#next-word-bounded-instance">§ 3.5.7 Find the next word bounded instance</a> of <var>query</var> in <var>text</var> from <var>search position</var> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale②">current locale</a>.</p>
          <div class="note" role="note"> If a prefix was specified, the search position is at the
-  beginning of <em>query</em> and this will advance it to the end
+  beginning of <var>query</var> and this will advance it to the end
   of the query to search for a potential suffix. Otherwise, this
   will find the next instance of query. </div>
         <li data-md>
-         <p>If <em>search position</em> is null, then break.</p>
+         <p>If <var>search position</var> is null, then break.</p>
         <li data-md>
-         <p>Let <em>potential match position</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable②">position variable</a> equal to <em>search
-position</em> minus the length of <em>query</em>.</p>
+         <p>Let <var>potential match position</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable②">position variable</a> equal to <var>search
+position</var> minus the length of <var>query</var>.</p>
         <li data-md>
-         <p>If <em>suffix</em> is the empty string, then return <em>potential
-match position</em>.</p>
+         <p>If <var>suffix</var> is the empty string, then return <var>potential
+match position</var>.</p>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace②">Skip ASCII whitespace</a> on <em>search position</em>.</p>
+         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace②">Skip ASCII whitespace</a> on <var>search position</var>.</p>
         <li data-md>
-         <p>If <em>search position</em> is at the end of <em>text</em>, then:</p>
+         <p>If <var>search position</var> is at the end of <var>text</var>, then:</p>
          <ol>
           <li data-md>
-           <p>Let <em>suffix_walker</em> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker②">TreeWalker</a></code> that is a copy of <em>walker</em>.</p>
+           <p>Let <var>suffix_walker</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker②">TreeWalker</a></code> that is a copy of <var>walker</var>.</p>
           <li data-md>
-           <p>Perform <a href="#advance-walker-to-text">§ 2.5.5 Advance a TreeWalker to the next text node</a> on <em>suffix_walker</em>.</p>
+           <p>Perform <a href="#advance-walker-to-text">§ 3.5.6 Advance a TreeWalker to the next text node</a> on <var>suffix_walker</var>.</p>
           <li data-md>
            <p>If <em>suffix_walker.currentNode</em> is null, then return null.</p>
           <li data-md>
-           <p>Set <em>text</em> to <em>suffix_walker.currentNode.innerText</em>.</p>
+           <p>Set <var>text</var> to <em>suffix_walker.currentNode.innerText</em>.</p>
           <li data-md>
-           <p>Set <em>search position</em> to the beginning of <em>text</em>.</p>
+           <p>Set <var>search position</var> to the beginning of <var>text</var>.</p>
           <li data-md>
-           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace③">Skip ASCII whitespace</a> on <em>search
-position</em>.</p>
+           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace③">Skip ASCII whitespace</a> on <var>search
+position</var>.</p>
          </ol>
         <li data-md>
-         <p>If the result of <a href="#next-word-bounded-instance">§ 2.5.6 Find the next word bounded instance</a> of <em>suffix</em> in <em>text</em> from <em>search position</em> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale③">current
-locale</a> starts at <em>search position</em>, then return <em>potential match position</em>.</p>
+         <p>If the result of <a href="#next-word-bounded-instance">§ 3.5.7 Find the next word bounded instance</a> of <var>suffix</var> in <var>text</var> from <var>search position</var> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale③">current
+locale</a> starts at <var>search position</var>, then return <var>potential match position</var>.</p>
        </ol>
       <li data-md>
-       <p>Perform <a href="#advance-walker-to-text">§ 2.5.5 Advance a TreeWalker to the next text node</a> on <em>walker</em>.</p>
+       <p>Perform <a href="#advance-walker-to-text">§ 3.5.6 Advance a TreeWalker to the next text node</a> on <var>walker</var>.</p>
      </ol>
     <li data-md>
      <p>Return null.</p>
    </ol>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="current-locale">current locale</dfn> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#language" id="ref-for-language">language</a> of the <em>currentNode</em>.</p>
-   <h4 class="heading settled" data-level="2.5.5" id="advance-walker-to-text"><span class="secno">2.5.5. </span><span class="content">Advance a TreeWalker to the next text node</span><a class="self-link" href="#advance-walker-to-text"></a></h4>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="current-locale">current locale</dfn> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#language" id="ref-for-language">language</a> of the <var>currentNode</var>.</p>
+   <h4 class="heading settled" data-level="3.5.6" id="advance-walker-to-text"><span class="secno">3.5.6. </span><span class="content">Advance a TreeWalker to the next text node</span><a class="self-link" href="#advance-walker-to-text"></a></h4>
    <div class="note" role="note"> The input <em>walker</em> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker③">TreeWalker</a></code> reference, not a
   copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
    <ol>
@@ -2209,7 +2231,7 @@ locale</a> starts at <em>search position</em>, then return <em>potential match p
        <p>Advance the current node by calling <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode" id="ref-for-dom-treewalker-nextnode">walker.nextNode()</a></code>.</p>
      </ol>
    </ol>
-   <h4 class="heading settled" data-level="2.5.6" id="next-word-bounded-instance"><span class="secno">2.5.6. </span><span class="content">Find the next word bounded instance</span><a class="self-link" href="#next-word-bounded-instance"></a></h4>
+   <h4 class="heading settled" data-level="3.5.7" id="next-word-bounded-instance"><span class="secno">3.5.7. </span><span class="content">Find the next word bounded instance</span><a class="self-link" href="#next-word-bounded-instance"></a></h4>
    <div class="note" role="note"> This algorithm has input <em>query, text, start position,</em> and <em>locale</em> and returns a Range that specifies the word bounded text
 instance if it is found. </div>
    <div class="note" role="note"> See <a href="https://github.com/tc39/proposal-intl-segmenter">Intl.Segmenter</a>,
@@ -2251,7 +2273,7 @@ bound</em> immediately follows <em>range</em>, then return <em>range</em>.</p>
     <li data-md>
      <p>Return <em>null</em>.</p>
    </ol>
-   <h3 class="heading settled" data-level="2.6" id="indicating-the-text-match"><span class="secno">2.6. </span><span class="content">Indicating The Text Match</span><a class="self-link" href="#indicating-the-text-match"></a></h3>
+   <h3 class="heading settled" data-level="3.6" id="indicating-the-text-match"><span class="secno">3.6. </span><span class="content">Indicating The Text Match</span><a class="self-link" href="#indicating-the-text-match"></a></h3>
    <p>The UA may choose to scroll the text fragment into view as part of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment①">try to scroll to the fragment</a> steps or by some other mechanism;
 however, it is not required to scroll the match into view.</p>
    <p>The UA should visually indicate the matched text in some way such that the user
@@ -2263,7 +2285,7 @@ However, the UA must not use the Document’s <a href="https://w3c.github.io/sel
 indicate the text match as doing so could allow attack vectors for content
 exfiltration.</p>
    <p>The UA must not visually indicate any provided context terms.</p>
-   <h3 class="heading settled" data-level="2.7" id="feature-detectability"><span class="secno">2.7. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
+   <h3 class="heading settled" data-level="3.7" id="feature-detectability"><span class="secno">3.7. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
 that is exposed via <code>window.location.fragmentDirective</code> if the UA
 supports the feature.</p>
@@ -2275,13 +2297,13 @@ supports the feature.</p>
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective①" id="ref-for-fragmentdirective①"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-location-fragmentdirective"></a></dfn>;
 };
 </pre>
-   <h2 class="heading settled" data-level="3" id="generating-text-fragment-directives"><span class="secno">3. </span><span class="content">Generating Text Fragment Directives</span><a class="self-link" href="#generating-text-fragment-directives"></a></h2>
+   <h2 class="heading settled" data-level="4" id="generating-text-fragment-directives"><span class="secno">4. </span><span class="content">Generating Text Fragment Directives</span><a class="self-link" href="#generating-text-fragment-directives"></a></h2>
    <div class="note" role="note"> This section is non-normative. </div>
    <p>This section contains recommendations for UAs automatically generating URLs
 with a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑧">text fragment directive</a>. These recommendations aren’t normative but
 are provided to ensure generated URLs result in maximally stable and usable
 URLs.</p>
-   <h3 class="heading settled" data-level="3.1" id="prefer-exact-matching-to-range-based"><span class="secno">3.1. </span><span class="content">Prefer Exact Matching To Range-based</span><a class="self-link" href="#prefer-exact-matching-to-range-based"></a></h3>
+   <h3 class="heading settled" data-level="4.1" id="prefer-exact-matching-to-range-based"><span class="secno">4.1. </span><span class="content">Prefer Exact Matching To Range-based</span><a class="self-link" href="#prefer-exact-matching-to-range-based"></a></h3>
    <p>The match text can be provided either as an exact string "text=foo%20bar%20baz"
 or as a range "text=foo,bar".</p>
    <p>UAs should prefer to specify the entire string where practical. This ensures
@@ -2312,7 +2334,7 @@ and encoding the entire string would produce an unwieldly URL.</p>
 encoded using an exact match. Above this limit, the UA should encode the string
 as a range-based match.</p>
    <div class="note" role="note"> TODO:  Can we determine the above limit in some more objective way? </div>
-   <h3 class="heading settled" data-level="3.2" id="use-context-only-when-necessary"><span class="secno">3.2. </span><span class="content">Use Context Only When Necessary</span><a class="self-link" href="#use-context-only-when-necessary"></a></h3>
+   <h3 class="heading settled" data-level="4.2" id="use-context-only-when-necessary"><span class="secno">4.2. </span><span class="content">Use Context Only When Necessary</span><a class="self-link" href="#use-context-only-when-necessary"></a></h3>
    <p>Context terms allow the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑨">text fragment directive</a> to disambiguate text
 snippets on a page. However, their use can make the URL more brittle in some
 cases. Often, the desired string will start or end at an element boundary. The
@@ -2339,7 +2361,7 @@ true:</p>
     <li>The quoted text contains 3 or fewer words
    </ul>
    <div class="note" role="note"> TODO: Determine the numeric limit above in a more objective way </div>
-   <h3 class="heading settled" data-level="3.3" id="determine-if-fragment-id-is-needed"><span class="secno">3.3. </span><span class="content">Determine If Fragment Id Is Needed</span><a class="self-link" href="#determine-if-fragment-id-is-needed"></a></h3>
+   <h3 class="heading settled" data-level="4.3" id="determine-if-fragment-id-is-needed"><span class="secno">4.3. </span><span class="content">Determine If Fragment Id Is Needed</span><a class="self-link" href="#determine-if-fragment-id-is-needed"></a></h3>
    <p>When the UA navigates to a URL containing a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive①②">text fragment directive</a>, it will
 fallback to scrolling into view a regular element-id based fragment if it
 exists and the text fragment isn’t found.</p>
@@ -2375,7 +2397,7 @@ manipulations
     <p><a href="https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations"> https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations</a></p>
    </div>
    <p>If a UA chooses not to scroll text fragments into view on navigation (reasons
-why a UA may make this choice are discussed in <a href="#security-and-privacy">§ 2.4 Security and Privacy</a>), it
+why a UA may make this choice are discussed in <a href="#security-and-privacy">§ 3.4 Security and Privacy</a>), it
 must scroll the element-id into view, if provided, regardless of whether a text
 fragment was matched. Not doing so would allow detecting the text fragment
 match based on whether the element-id was scrolled.</p>
@@ -2529,264 +2551,277 @@ match based on whether the element-id was scrolled.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#characterstring">CharacterString</a><span>, in §2.3.2</span>
-   <li><a href="#current-locale">current locale</a><span>, in §2.5.4</span>
-   <li><a href="#explicitchar">ExplicitChar</a><span>, in §2.3.2</span>
-   <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §2.7</span>
-   <li><a href="#fragment-directive">fragment directive</a><span>, in §2.3.1</span>
+   <li><a href="#characterstring">CharacterString</a><span>, in §3.3.2</span>
+   <li><a href="#current-locale">current locale</a><span>, in §3.5.5</span>
+   <li><a href="#explicitchar">ExplicitChar</a><span>, in §3.3.2</span>
+   <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §3.7</span>
+   <li><a href="#fragment-directive">fragment directive</a><span>, in §3.3.1</span>
    <li>
     FragmentDirective
     <ul>
-     <li><a href="#fragmentdirective①">(interface)</a><span>, in §2.7</span>
-     <li><a href="#fragmentdirective">definition of</a><span>, in §2.3.2</span>
+     <li><a href="#fragmentdirective①">(interface)</a><span>, in §3.7</span>
+     <li><a href="#fragmentdirective">definition of</a><span>, in §3.3.2</span>
     </ul>
-   <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §2.3.1</span>
-   <li><a href="#location">Location</a><span>, in §2.7</span>
-   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §2.3.2</span>
-   <li><a href="#scroll-a-domrect-into-view">scroll a DOMRect into view</a><span>, in §2.5.1</span>
-   <li><a href="#scroll-a-range-into-view">scroll a Range into view</a><span>, in §2.5.1</span>
-   <li><a href="#textdirective">TextDirective</a><span>, in §2.3.2</span>
-   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §2.3.2</span>
-   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §2.3.2</span>
-   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §2.3.2</span>
-   <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §2.3.2</span>
-   <li><a href="#unknowndirective">UnknownDirective</a><span>, in §2.3.2</span>
-   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §2.3.2</span>
+   <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §3.3.1</span>
+   <li><a href="#location">Location</a><span>, in §3.7</span>
+   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §3.3.2</span>
+   <li><a href="#scroll-a-domrect-into-view">scroll a DOMRect into view</a><span>, in §3.5.1</span>
+   <li><a href="#scroll-a-range-into-view">scroll a Range into view</a><span>, in §3.5.1</span>
+   <li><a href="#textdirective">TextDirective</a><span>, in §3.3.2</span>
+   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §3.3.2</span>
+   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §3.3.2</span>
+   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §3.3.2</span>
+   <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §3.3.2</span>
+   <li><a href="#unknowndirective">UnknownDirective</a><span>, in §3.3.2</span>
+   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §3.3.2</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-dictdef-scrollintoviewoptions">
    <a href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions">https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-scrollintoviewoptions">2.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-dictdef-scrollintoviewoptions①">(2)</a>
+    <li><a href="#ref-for-dictdef-scrollintoviewoptions">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-dictdef-scrollintoviewoptions①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-range-getboundingclientrect">
    <a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-range-getboundingclientrect">2.5.1. Scroll a DOMRect into view</a>
+    <li><a href="#ref-for-dom-range-getboundingclientrect">3.5.1. Scroll a DOMRect into view</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-scroll-an-element-into-view">
    <a href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view">https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scroll-an-element-into-view">2.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-scroll-an-element-into-view①">2.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-an-element-into-view②">(2)</a> <a href="#ref-for-scroll-an-element-into-view③">(3)</a> <a href="#ref-for-scroll-an-element-into-view④">(4)</a>
+    <li><a href="#ref-for-scroll-an-element-into-view">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-scroll-an-element-into-view①">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-an-element-into-view②">(2)</a> <a href="#ref-for-scroll-an-element-into-view③">(3)</a> <a href="#ref-for-scroll-an-element-into-view④">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document">
    <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document">2.4.4. Should Allow Text Fragment</a>
+    <li><a href="#ref-for-document">3.4.4. Should Allow Text Fragment</a>
+    <li><a href="#ref-for-document①">3.5.4. Find a matching Range</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-node-element_node">
    <a href="https://dom.spec.whatwg.org/#dom-node-element_node">https://dom.spec.whatwg.org/#dom-node-element_node</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-node-element_node">2.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-dom-node-element_node">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-element">
    <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-element">2.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-element①">2.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-element②">(2)</a>
+    <li><a href="#ref-for-element">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-element①">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-element②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-range">
    <a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-range">2.5. Navigating to a Text Fragment</a> <a href="#ref-for-range①">(2)</a> <a href="#ref-for-range②">(3)</a> <a href="#ref-for-range③">(4)</a>
-    <li><a href="#ref-for-range④">2.5.1. Scroll a DOMRect into view</a>
-    <li><a href="#ref-for-range⑤">2.5.2. Find text matches</a> <a href="#ref-for-range⑥">(2)</a>
-    <li><a href="#ref-for-range⑦">2.5.3. Find a target text</a> <a href="#ref-for-range⑧">(2)</a>
+    <li><a href="#ref-for-range">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-range①">(2)</a> <a href="#ref-for-range②">(3)</a> <a href="#ref-for-range③">(4)</a>
+    <li><a href="#ref-for-range④">3.5.1. Scroll a DOMRect into view</a>
+    <li><a href="#ref-for-range⑤">3.5.2. Find text matches</a> <a href="#ref-for-range⑥">(2)</a>
+    <li><a href="#ref-for-range⑦">3.5.4. Find a matching Range</a> <a href="#ref-for-range⑧">(2)</a> <a href="#ref-for-range⑨">(3)</a> <a href="#ref-for-range①⓪">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-treewalker">
    <a href="https://dom.spec.whatwg.org/#treewalker">https://dom.spec.whatwg.org/#treewalker</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-treewalker">2.5.3. Find a target text</a>
-    <li><a href="#ref-for-treewalker①">2.5.4. Find an exact match with context</a> <a href="#ref-for-treewalker②">(2)</a>
-    <li><a href="#ref-for-treewalker③">2.5.5. Advance a TreeWalker to the next text node</a>
+    <li><a href="#ref-for-treewalker">3.5.4. Find a matching Range</a>
+    <li><a href="#ref-for-treewalker①">3.5.5. Find an exact match with context</a> <a href="#ref-for-treewalker②">(2)</a>
+    <li><a href="#ref-for-treewalker③">3.5.6. Advance a TreeWalker to the next text node</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-range-commonancestorcontainer">
    <a href="https://dom.spec.whatwg.org/#dom-range-commonancestorcontainer">https://dom.spec.whatwg.org/#dom-range-commonancestorcontainer</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-range-commonancestorcontainer">2.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-dom-range-commonancestorcontainer">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-document-createtreewalker">
    <a href="https://dom.spec.whatwg.org/#dom-document-createtreewalker">https://dom.spec.whatwg.org/#dom-document-createtreewalker</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-document-createtreewalker">2.5.3. Find a target text</a>
+    <li><a href="#ref-for-dom-document-createtreewalker">3.5.4. Find a matching Range</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-document">
    <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document">2.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-concept-document">3.3.1. Parsing the fragment directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-treewalker-nextnode">
    <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode">https://dom.spec.whatwg.org/#dom-treewalker-nextnode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-treewalker-nextnode">2.5.5. Advance a TreeWalker to the next text node</a>
+    <li><a href="#ref-for-dom-treewalker-nextnode">3.5.6. Advance a TreeWalker to the next text node</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-node-nodetype">
    <a href="https://dom.spec.whatwg.org/#dom-node-nodetype">https://dom.spec.whatwg.org/#dom-node-nodetype</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-node-nodetype">2.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-dom-node-nodetype">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-node-parentnode">
    <a href="https://dom.spec.whatwg.org/#dom-node-parentnode">https://dom.spec.whatwg.org/#dom-node-parentnode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-node-parentnode">2.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-dom-node-parentnode">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-document-url">
    <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document-url">2.3.1. Parsing the fragment directive</a> <a href="#ref-for-concept-document-url①">(2)</a> <a href="#ref-for-concept-document-url②">(3)</a>
+    <li><a href="#ref-for-concept-document-url">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-concept-document-url①">(2)</a> <a href="#ref-for-concept-document-url②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
    <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-current-url">2.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-concept-request-current-url">3.3.1. Parsing the fragment directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-url">
    <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-url">2.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-concept-response-url">3.3.1. Parsing the fragment directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-domrect">
    <a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-domrect">2.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-domrect①">(2)</a>
+    <li><a href="#ref-for-domrect">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-domrect①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-browsing-context">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-browsing-context">2.4.4. Should Allow Text Fragment</a>
+    <li><a href="#ref-for-browsing-context">3.4.4. Should Allow Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-browsing-context-set">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-set">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-set</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-browsing-context-set">2.4.4. Should Allow Text Fragment</a>
+    <li><a href="#ref-for-browsing-context-set">3.4.4. Should Allow Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-language">
    <a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-language">2.5.4. Find an exact match with context</a>
+    <li><a href="#ref-for-language">3.5.5. Find an exact match with context</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-latest-entry">
    <a href="https://html.spec.whatwg.org/multipage/history.html#latest-entry">https://html.spec.whatwg.org/multipage/history.html#latest-entry</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-latest-entry">2.4.4. Should Allow Text Fragment</a>
+    <li><a href="#ref-for-latest-entry">3.4.4. Should Allow Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-scroll-to-the-fragment-identifier">
    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier">https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scroll-to-the-fragment-identifier">2.4.5. allowTextFragmentDirective flag</a>
-    <li><a href="#ref-for-scroll-to-the-fragment-identifier①">2.5. Navigating to a Text Fragment</a> <a href="#ref-for-scroll-to-the-fragment-identifier②">(2)</a>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier">3.4.5. allowTextFragmentDirective flag</a>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier①">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-scroll-to-the-fragment-identifier②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-session-history">
    <a href="https://html.spec.whatwg.org/multipage/history.html#session-history">https://html.spec.whatwg.org/multipage/history.html#session-history</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-session-history">2.4.4. Should Allow Text Fragment</a>
+    <li><a href="#ref-for-session-history">3.4.4. Should Allow Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-the-indicated-part-of-the-document">
    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-indicated-part-of-the-document">2.5. Navigating to a Text Fragment</a> <a href="#ref-for-the-indicated-part-of-the-document①">(2)</a>
+    <li><a href="#ref-for-the-indicated-part-of-the-document">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-the-indicated-part-of-the-document①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-try-to-scroll-to-the-fragment">
    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-try-to-scroll-to-the-fragment">2.4.5. allowTextFragmentDirective flag</a>
-    <li><a href="#ref-for-try-to-scroll-to-the-fragment①">2.6. Indicating The Text Match</a>
+    <li><a href="#ref-for-try-to-scroll-to-the-fragment">3.4.5. allowTextFragmentDirective flag</a>
+    <li><a href="#ref-for-try-to-scroll-to-the-fragment①">3.6. Indicating The Text Match</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-append">
    <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-append">2.5.2. Find text matches</a>
+    <li><a href="#ref-for-list-append">3.5.2. Find text matches</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-string-length">
+   <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-string-length">3.5.4. Find a matching Range</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list">
    <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list">2.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-list①">2.5.2. Find text matches</a> <a href="#ref-for-list②">(2)</a> <a href="#ref-for-list③">(3)</a> <a href="#ref-for-list④">(4)</a>
-    <li><a href="#ref-for-list⑤">2.5.3. Find a target text</a>
+    <li><a href="#ref-for-list">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-list①">3.5.2. Find text matches</a> <a href="#ref-for-list②">(2)</a> <a href="#ref-for-list③">(3)</a> <a href="#ref-for-list④">(4)</a>
+    <li><a href="#ref-for-list⑤">3.5.3. Parse a text directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-string-position-variable">
    <a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string-position-variable">2.3.1. Parsing the fragment directive</a>
-    <li><a href="#ref-for-string-position-variable①">2.5.3. Find a target text</a>
-    <li><a href="#ref-for-string-position-variable②">2.5.4. Find an exact match with context</a>
+    <li><a href="#ref-for-string-position-variable">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-string-position-variable①">3.5.4. Find a matching Range</a>
+    <li><a href="#ref-for-string-position-variable②">3.5.5. Find an exact match with context</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-remove">
    <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-remove">2.5.3. Find a target text</a> <a href="#ref-for-list-remove①">(2)</a>
+    <li><a href="#ref-for-list-remove">3.5.3. Parse a text directive</a> <a href="#ref-for-list-remove①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-size">
    <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-size">2.5.3. Find a target text</a> <a href="#ref-for-list-size①">(2)</a> <a href="#ref-for-list-size②">(3)</a>
+    <li><a href="#ref-for-list-size">3.5.3. Parse a text directive</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-skip-ascii-whitespace">
    <a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">https://infra.spec.whatwg.org/#skip-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-skip-ascii-whitespace">2.5.4. Find an exact match with context</a> <a href="#ref-for-skip-ascii-whitespace①">(2)</a> <a href="#ref-for-skip-ascii-whitespace②">(3)</a> <a href="#ref-for-skip-ascii-whitespace③">(4)</a>
+    <li><a href="#ref-for-skip-ascii-whitespace">3.5.5. Find an exact match with context</a> <a href="#ref-for-skip-ascii-whitespace①">(2)</a> <a href="#ref-for-skip-ascii-whitespace②">(3)</a> <a href="#ref-for-skip-ascii-whitespace③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-split-on-commas">
    <a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-split-on-commas">2.5.3. Find a target text</a>
+    <li><a href="#ref-for-split-on-commas">3.5.3. Parse a text directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-strictly-split">
    <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-strictly-split">2.5.2. Find text matches</a>
+    <li><a href="#ref-for-strictly-split">3.5.2. Find text matches</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-string">
    <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string">2.5.2. Find text matches</a> <a href="#ref-for-string①">(2)</a> <a href="#ref-for-string②">(3)</a>
-    <li><a href="#ref-for-string③">2.5.3. Find a target text</a> <a href="#ref-for-string④">(2)</a>
+    <li><a href="#ref-for-string">3.5.2. Find text matches</a> <a href="#ref-for-string①">(2)</a> <a href="#ref-for-string②">(3)</a>
+    <li><a href="#ref-for-string③">3.5.4. Find a matching Range</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-struct">
+   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-struct">3.5.3. Parse a text directive</a> <a href="#ref-for-struct①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
    <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-fragment">2.3.1. Parsing the fragment directive</a> <a href="#ref-for-concept-url-fragment①">(2)</a>
+    <li><a href="#ref-for-concept-url-fragment">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-concept-url-fragment①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-url-code-points">
    <a href="https://url.spec.whatwg.org/#url-code-points">https://url.spec.whatwg.org/#url-code-points</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-url-code-points">2.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-url-code-points">3.3.2. Fragment directive grammar</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2841,6 +2876,7 @@ match based on whether the element-id was scrolled.</p>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-list-append" style="color:initial">append</span>
+     <li><span class="dfn-paneled" id="term-for-string-length" style="color:initial">length</span>
      <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
      <li><span class="dfn-paneled" id="term-for-string-position-variable" style="color:initial">position variable</span>
      <li><span class="dfn-paneled" id="term-for-list-remove" style="color:initial">remove</span>
@@ -2849,6 +2885,7 @@ match based on whether the element-id was scrolled.</p>
      <li><span class="dfn-paneled" id="term-for-split-on-commas" style="color:initial">split on commas</span>
      <li><span class="dfn-paneled" id="term-for-strictly-split" style="color:initial">strictly split a string</span>
      <li><span class="dfn-paneled" id="term-for-string" style="color:initial">string</span>
+     <li><span class="dfn-paneled" id="term-for-struct" style="color:initial">struct</span>
     </ul>
    <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
@@ -2889,116 +2926,116 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="fragment-directive">
    <b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragment-directive">2.2. Syntax</a>
-    <li><a href="#ref-for-fragment-directive①">2.3. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a>
-    <li><a href="#ref-for-fragment-directive④">2.3.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a> <a href="#ref-for-fragment-directive⑨">(6)</a>
-    <li><a href="#ref-for-fragment-directive①⓪">2.3.2. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①①">(2)</a>
-    <li><a href="#ref-for-fragment-directive①②">2.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-fragment-directive">3.2. Syntax</a>
+    <li><a href="#ref-for-fragment-directive①">3.3. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a>
+    <li><a href="#ref-for-fragment-directive④">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a> <a href="#ref-for-fragment-directive⑨">(6)</a>
+    <li><a href="#ref-for-fragment-directive①⓪">3.3.2. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①①">(2)</a>
+    <li><a href="#ref-for-fragment-directive①②">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragment-directive-delimiter">
    <b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragment-directive-delimiter">2.3.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter①">(2)</a> <a href="#ref-for-fragment-directive-delimiter②">(3)</a>
+    <li><a href="#ref-for-fragment-directive-delimiter">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter①">(2)</a> <a href="#ref-for-fragment-directive-delimiter②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragmentdirective">
    <b><a href="#fragmentdirective">#fragmentdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragmentdirective">2.3.2. Fragment directive grammar</a> <a href="#ref-for-fragmentdirective②">(2)</a>
-    <li><a href="#ref-for-fragmentdirective③">2.5.2. Find text matches</a>
+    <li><a href="#ref-for-fragmentdirective">3.3.2. Fragment directive grammar</a> <a href="#ref-for-fragmentdirective②">(2)</a>
+    <li><a href="#ref-for-fragmentdirective③">3.5.2. Find text matches</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="unknowndirective">
    <b><a href="#unknowndirective">#unknowndirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-unknowndirective">2.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-unknowndirective">3.3.2. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="text-fragment-directive">
    <b><a href="#text-fragment-directive">#text-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-text-fragment-directive">2.2. Syntax</a>
-    <li><a href="#ref-for-text-fragment-directive①">2.4.1. Motivation</a> <a href="#ref-for-text-fragment-directive②">(2)</a> <a href="#ref-for-text-fragment-directive③">(3)</a> <a href="#ref-for-text-fragment-directive④">(4)</a>
-    <li><a href="#ref-for-text-fragment-directive⑤">2.4.3. Search Timing</a>
-    <li><a href="#ref-for-text-fragment-directive⑥">2.4.4. Should Allow Text Fragment</a>
-    <li><a href="#ref-for-text-fragment-directive⑦">2.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-text-fragment-directive⑧">3. Generating Text Fragment Directives</a>
-    <li><a href="#ref-for-text-fragment-directive⑨">3.2. Use Context Only When Necessary</a> <a href="#ref-for-text-fragment-directive①⓪">(2)</a> <a href="#ref-for-text-fragment-directive①①">(3)</a>
-    <li><a href="#ref-for-text-fragment-directive①②">3.3. Determine If Fragment Id Is Needed</a> <a href="#ref-for-text-fragment-directive①③">(2)</a>
+    <li><a href="#ref-for-text-fragment-directive">3.2. Syntax</a>
+    <li><a href="#ref-for-text-fragment-directive①">3.4.1. Motivation</a> <a href="#ref-for-text-fragment-directive②">(2)</a> <a href="#ref-for-text-fragment-directive③">(3)</a> <a href="#ref-for-text-fragment-directive④">(4)</a>
+    <li><a href="#ref-for-text-fragment-directive⑤">3.4.3. Search Timing</a>
+    <li><a href="#ref-for-text-fragment-directive⑥">3.4.4. Should Allow Text Fragment</a>
+    <li><a href="#ref-for-text-fragment-directive⑦">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-text-fragment-directive⑧">4. Generating Text Fragment Directives</a>
+    <li><a href="#ref-for-text-fragment-directive⑨">4.2. Use Context Only When Necessary</a> <a href="#ref-for-text-fragment-directive①⓪">(2)</a> <a href="#ref-for-text-fragment-directive①①">(3)</a>
+    <li><a href="#ref-for-text-fragment-directive①②">4.3. Determine If Fragment Id Is Needed</a> <a href="#ref-for-text-fragment-directive①③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirective">
    <b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirective">2.3.2. Fragment directive grammar</a> <a href="#ref-for-textdirective①">(2)</a>
-    <li><a href="#ref-for-textdirective②">2.5.2. Find text matches</a>
+    <li><a href="#ref-for-textdirective">3.3.2. Fragment directive grammar</a> <a href="#ref-for-textdirective①">(2)</a>
+    <li><a href="#ref-for-textdirective②">3.5.2. Find text matches</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveparameters">
    <b><a href="#textdirectiveparameters">#textdirectiveparameters</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectiveparameters">2.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-textdirectiveparameters">3.3.2. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveprefix">
    <b><a href="#textdirectiveprefix">#textdirectiveprefix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectiveprefix">2.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-textdirectiveprefix">3.3.2. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectivesuffix">
    <b><a href="#textdirectivesuffix">#textdirectivesuffix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectivesuffix">2.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-textdirectivesuffix">3.3.2. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="characterstring">
    <b><a href="#characterstring">#characterstring</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-characterstring">2.3.2. Fragment directive grammar</a> <a href="#ref-for-characterstring①">(2)</a> <a href="#ref-for-characterstring②">(3)</a> <a href="#ref-for-characterstring③">(4)</a> <a href="#ref-for-characterstring④">(5)</a>
+    <li><a href="#ref-for-characterstring">3.3.2. Fragment directive grammar</a> <a href="#ref-for-characterstring①">(2)</a> <a href="#ref-for-characterstring②">(3)</a> <a href="#ref-for-characterstring③">(4)</a> <a href="#ref-for-characterstring④">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="explicitchar">
    <b><a href="#explicitchar">#explicitchar</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-explicitchar">2.3.2. Fragment directive grammar</a> <a href="#ref-for-explicitchar①">(2)</a>
+    <li><a href="#ref-for-explicitchar">3.3.2. Fragment directive grammar</a> <a href="#ref-for-explicitchar①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="percentencodedchar">
    <b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-percentencodedchar">2.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-percentencodedchar">3.3.2. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="scroll-a-domrect-into-view">
    <b><a href="#scroll-a-domrect-into-view">#scroll-a-domrect-into-view</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scroll-a-domrect-into-view">2.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-a-domrect-into-view①">(2)</a> <a href="#ref-for-scroll-a-domrect-into-view②">(3)</a> <a href="#ref-for-scroll-a-domrect-into-view③">(4)</a>
+    <li><a href="#ref-for-scroll-a-domrect-into-view">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-a-domrect-into-view①">(2)</a> <a href="#ref-for-scroll-a-domrect-into-view②">(3)</a> <a href="#ref-for-scroll-a-domrect-into-view③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="scroll-a-range-into-view">
    <b><a href="#scroll-a-range-into-view">#scroll-a-range-into-view</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scroll-a-range-into-view">2.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-scroll-a-range-into-view">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="current-locale">
    <b><a href="#current-locale">#current-locale</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-locale">2.5.4. Find an exact match with context</a> <a href="#ref-for-current-locale①">(2)</a> <a href="#ref-for-current-locale②">(3)</a> <a href="#ref-for-current-locale③">(4)</a>
+    <li><a href="#ref-for-current-locale">3.5.5. Find an exact match with context</a> <a href="#ref-for-current-locale①">(2)</a> <a href="#ref-for-current-locale②">(3)</a> <a href="#ref-for-current-locale③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragmentdirective①">
    <b><a href="#fragmentdirective①">#fragmentdirective①</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragmentdirective①">2.7. Feature Detectability</a>
+    <li><a href="#ref-for-fragmentdirective①">3.7. Feature Detectability</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="location">
    <b><a href="#location">#location</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-location">2.7. Feature Detectability</a>
+    <li><a href="#ref-for-location">3.7. Feature Detectability</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -2089,7 +2089,7 @@ these steps:</p>
     <li data-md>
      <p>Let <var>parsed values</var> be the result of running <a href="#parse-a-text-directive">§ 3.5.3 Parse a text directive</a> on <var>directive</var>.</p>
     <li data-md>
-     <p>If <em>parsed values</em> is null, return null.</p>
+     <p>If <var>parsed values</var> is null, return null.</p>
     <li data-md>
      <p>Let <var>prefix</var>, <var>textStart</var>, <var>textEnd</var>, and <var>suffix</var> be the values of the
    equivalent items in <var>parsed values</var>.</p>
@@ -2098,7 +2098,7 @@ these steps:</p>
     <li data-md>
      <p>Let <var>position</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable①">position variable</a> that indicates a text offset in <em>walker.currentNode.innerText</em>.</p>
     <li data-md>
-     <p>If <var>textEnd</var> is the empty string, then:</p>
+     <p>If <var>textEnd</var> is null, then:</p>
      <ol>
       <li data-md>
        <p>Let <var>match position</var> be the result of <a href="#find-match-with-context">§ 3.5.5 Find an exact match with context</a> with input walker <var>walker</var>, search position <var>position</var>,
@@ -2146,7 +2146,7 @@ position <var>match position</var> and length equal to the <a data-link-type="df
        <p>While <var>search position</var> does not point past the end of <var>text</var>:</p>
        <ol>
         <li data-md>
-         <p>If <var>prefix</var> is not the empty string, then:</p>
+         <p>If <var>prefix</var> is not null, then:</p>
          <ol>
           <li data-md>
            <p>Advance <var>search position</var> to the position after the result
@@ -2188,7 +2188,7 @@ position</var>, then continue.</p>
          <p>Let <var>potential match position</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable②">position variable</a> equal to <var>search
 position</var> minus the length of <var>query</var>.</p>
         <li data-md>
-         <p>If <var>suffix</var> is the empty string, then return <var>potential
+         <p>If <var>suffix</var> is null, then return <var>potential
 match position</var>.</p>
         <li data-md>
          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace②">Skip ASCII whitespace</a> on <var>search position</var>.</p>


### PR DESCRIPTION
This is a small cleanup that makes it a bit easier to follow the logic
for finding a Range from a text directive by splitting out the logic
that parses the string into its individual components.

Also renames `Find a target text` to `Find a matching Range` to
more clearly indicate that the algorithm turns a text directive into
a Range in the Document.

This is a first step in fixing and improving some of the issues in the
tree walking algorithm as part of #73.