### PR TITLE
Testing pr-preview *DoNotMerge*

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -687,6 +687,33 @@ To <dfn>find range from a text directive</dfn>, run the following steps:
   which case context on that side of a match is not checked. e.g. If |prefix|
   is null, text is matched without any requirement on what text precedes it.
 </div>
+<div class="note">
+  While the matching text and its prefix/suffix can span across
+  block-boundaries, the individual parameters to these steps cannot. That is,
+  each of |prefix|, |textStart|, |textEnd|, and |suffix| will only match text
+  within a single block.
+
+  <div class="example">
+    <pre>:~:text=The quick,lazy dog</pre> will fail to match in
+
+    ```
+    <div>The<div> </div>quick brown fox</div>
+    <div>jumped over the lazy dog</div>
+    ```
+
+    because the starting string "The quick" does not appear within a single,
+    uninterrupted block. The instance of "The quick" in the document has a
+    block element between "The" and "quick".
+
+    It does, however, match in this example:
+
+    ```
+    <div>The quick brown fox</div>
+    <div>jumped over the lazy dog</div>
+    ```
+
+  </div>
+</div>
 
 1. Let |searchRange| be a {{Range}} with [=range/start=] (|document|, 0) and
    [=range/end=] (|document|, |document|'s [=node/length=])
@@ -812,7 +839,10 @@ in a given {{Range}} |range|, run these steps:
     ```
   </p>
 
-  Will perform a search on "abc", then on "c", then on "e".
+  Will perform a search on "abc", then on "d", then on "e".
+
+  Thus, |query| will only match text that is continuous (i.e. uninterrupted by
+  a block-level container) within a single block-level container.
 </div>
 
 1. While |searchRange| is not [=range/collapsed=]:

--- a/index.bs
+++ b/index.bs
@@ -146,9 +146,9 @@ translation-hints or enabling accessibility features.
 To the definition of [=Document=], add:
 
 <em>
-Each document has an associated <dfn>fragment directive</dfn> which is either
-null or an ASCII string holding data used by the UA to process the resource. It
-is initially null.
+  Each document has an associated <dfn>fragment directive</dfn> which is either
+  null or an ASCII string holding data used by the UA to process the resource. It
+  is initially null.
 </em>
 
 The <dfn>fragment directive delimiter</dfn> is the string ":~:", that is the
@@ -212,6 +212,56 @@ Replace steps 7 and 8 of this algorithm with:
 the fragment is the string "test" and the [=fragment directive=] is the string
 "text=foo".
 </div>
+
+To <dfn>parse a text directive</dfn>, on a <a spec="infra">string</a> |string|,
+run these steps:
+
+<div class="note">
+  <p>
+    This algorithm takes a single text directive string as input (e.g.
+    "text=prefix-,foo,bar") and attempts to parse the string into the
+    components of the directive (e.g. ("prefix", "foo", "bar", null)). See
+    [[#syntax]] for the what each of these components means and how they're
+    used.
+  </p>
+  <p>
+    Returns null if the input is invalid or fails to parse in any way.
+    Otherwise, returns a <a spec=infra>struct</a> containing four strings:
+    |textStart|, |textEnd|, |prefix|, |suffix|.
+    Only |textStart| is required to be non-null as the other parameters
+    are optional and may be omitted in a valid text directive string.
+  </p>
+</div>
+
+1. [=/assert=]: |raw target text| matches the production [=TextDirective=].
+1. Let |raw target text| be the substring of |text directive
+   input| starting at index 5.
+   <div class="note">
+     This is the remainder of the |text directive input| following,
+     but not including, the "text=" prefix.
+   </div>
+1. Let |tokens| be a <a for=/>list</a> of strings that is the result of
+   <a lt="split on commas">splitting |raw target text| on commas</a>.
+1. If |tokens| has size less than 1 or greater than 4, return null.
+1. If any of |tokens|' items are the empty string, return null.
+1. Let |retVal| be a <a spec=infra>struct</a> consisting of four strings:
+   |textStart|, |textEnd|, |prefix| and |suffix|, each initialized to null.
+1. Let |potential prefix| be the first item of |tokens|.
+1. If the last character of |potential prefix| is U+002D (-), then:
+    1. Set <em>retVal.prefix</em> to the result of removing the last character from
+       |potential prefix|.
+    1. <a spec=infra for=list>Remove</a> the first item of the list |tokens|.
+1. Let |potential suffix| be the last item of |tokens|, if one exists.
+1. If the first character of |potential suffix| is U+002D (-), then:
+    1. Set <em>retVal.suffix</em> to the result of removing the first character from
+       |potential suffix|.
+    1. <a spec=infra for=list>Remove</a> the last item of the list |tokens|.
+1. If |tokens| has <a spec=infra for=list>size</a> not equal to 1 nor 2 then
+   return null.
+1. Let <em>retVal.textStart</em> be the first item of |tokens|.
+1. If |tokens| has <a spec=infra for=list>size</a> 2, then let
+   <em>retVal.textEnd</em> be the last item of |tokens|.
+1. Return |retVal|
 
 ### Fragment directive grammar ### {#fragment-directive-grammar}
 A <dfn>valid fragment directive</dfn> is a sequence of characters that appears
@@ -293,7 +343,7 @@ information to the page.
 <div class="note">
   TODO: This last paragraph and example are probably not be necessary - the
   page can already determine what the user is looking at based on the viewport
-  rect. It may not be desireable since it would prevent use cases like
+  rect. It may not be desirable since it would prevent use cases like
   marginalia, allowing pages to provide UA and linking based on the text
   fragment.
 </div>
@@ -318,7 +368,7 @@ detectable and distinguished from natural user scrolls.
   An origin embedded in an iframe in the target page registers an
   IntersectionObserver and determines in the first 500ms of page load whether
   a scroll has occurred. This scroll can be indicative of whether the text
-  fragment was successfuly found on the page.
+  fragment was successfully found on the page.
 </div>
 
 <div class="example">
@@ -373,7 +423,7 @@ attackers from trying to secretly automate a search in background documents.
 
 A naive implementation of the text search algorithm could allow information
 exfiltration based on runtime duration differences between a matching and non-
-matching query. If an attacker were to find a way to synchronously navigate
+matching query. If an attacker could find a way to synchronously navigate
 to a [=text fragment directive=]-invoking URL, they would be able to determine
 the existence of a text snippet by measuring how long the navigation call takes.
 
@@ -390,7 +440,7 @@ has been successfully found</em>.
 This specification does not specify exactly how a UA achieves this as there are
 multiple solutions with differing tradeoffs. For example, a UA <em>may</em>
 continue to walk the tree even after a match is found in
-[[#find-a-matching-range]].  Alternatively, it <em>may</em> schedule an
+[[#text-directive-to-range]].  Alternatively, it <em>may</em> schedule an
 asynchronous task to find and set the indicated part of the document.
 
 ### Should Allow Text Fragment ### {#should-allow-text-fragment}
@@ -498,27 +548,23 @@ the following:
 Add the following steps to the beginning of the processing model for
 <a spec=HTML>the indicated part of the document</a>:
 
-1. Let <em>fragment directive string</em> be the <em>document</em>'s [=fragment
-    directive=].
-2. If <em>document</em>'s [[#allow-text-fragment-directive-flag]] is true then:
-    1. Let <em>ranges</em> be a <a spec=infra>list</a> that is the result of
-        [[#find-text-matches]] with <em>fragment directive string</em>.
-    2. If <em>ranges</em> is non-empty, then:
-        1. Let <em>range</em> be the first item of <em>ranges</em>.
-            <div class="note">
-            The first {{Range}} in <em>ranges</em> is specifically
-            scrolled into view. This {{Range}}, along with the
-            remaining <em>ranges</em> should be visually indicated in a way that
-            is not revealed to script, which is left as UA-defined behavior.
-            </div>
-        2. Let <em>node</em> be <em>range</em>'s
-            {{Range/commonAncestorContainer}}.
-        3. While <em>node</em>'s {{Node/nodeType}} is not
-            {{Node/ELEMENT_NODE}}:
-            1. Set <em>node</em> to <em>node</em>'s
-                {{Node/parentNode}}.
-        4. The indicated part of the document is <em>node</em> and
-            <em>range</em>; return.
+1. Let |fragment directive string| be the |document|'s [=fragment directive=].
+1. If |document|'s [[#allow-text-fragment-directive-flag]] is true then:
+    1. Let |ranges| be a <a spec=infra>list</a> that is the result of running
+       the [=process a fragment directive=] steps with |fragment directive
+       string| and |document|.
+    1. If |ranges| is non-empty, then:
+        1. Let |range| be the first item of |ranges|.
+           <div class="note">
+             The first {{Range}} in |ranges| is specifically
+             scrolled into view. This {{Range}}, along with the
+             remaining |ranges| should be visually indicated in a way that
+             is not revealed to script, which is left as UA-defined behavior.
+           </div>
+        1. Let |node| be |range|'s {{Range/commonAncestorContainer}}.
+        1. While |node|'s {{Node/nodeType}} is not {{Node/ELEMENT_NODE}}:
+            1. Set |node| to |node|'s {{Node/parentNode}}.
+        1. The indicated part of the document is |node| and |range|; return.
 
 ### Scroll a DOMRect into view ### {#scroll-rect-into-view}
 <div class="note">
@@ -555,223 +601,392 @@ Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
 2. Perform [=scroll a DOMRect into view=] on <em>bounding rect</em> with
     <em>options</em> and startingElement <em>containingElement</em>.
 
-### Find text matches ### {#find-text-matches}
+### Finding Ranges in a Document ### {#finding-ranges-in-a-document}
 
 <div class="note">
-  This algorithm has input <em>fragment directive input</em>, that is the raw
-  fragment directive <a spec=infra>string</a>, and returns a
-  <a spec=infra>list</a> of {{Range}}s that are to be visually indicated, the
-  first of which should be scrolled into view.
+  This section outlines several algorithms and definitions that specify how to
+  turn a full fragment directive string into a list of {{Ranges}} in the
+  document.
+
+  At a high level, we take a fragment directive string that looks like this:
+  <pre>
+    text=prefix-,foo&unknown&text=bar,baz
+  </pre>
+
+  We break this up into the individual text directives:
+
+  <pre>
+    text=prefix-,foo
+    text=bar,baz
+  </pre>
+
+  For each text directive, we perform a search in the document for the first
+  instance of rendered text that matches the restrictions in the directive.
+  Each search is independent of any others; that is, the result is the same
+  regardless of how many other directives are provided or their match result.
+
+  If a directive successfully matches to text in the document, it returns a
+  {{Range}} indicating that match in the document. The [=process a fragment
+  directive=] steps are the high level API provided by this section. These
+  return a <a spec=infra>list</a> of {{Range}}s that were matched by the
+  individual directive matching steps, in the order the directives were
+  specified in the fragment directive string.
+
+  If a directive was not matched, it does not add an item to the returned
+  list.
 </div>
 
-1. If <em>fragment directive input</em> does not match the [=FragmentDirective=]
-    production, then return an empty <a spec=infra>list</a>.
+To <dfn>process a fragment directive</dfn>, run these steps:
+
+<div class="note">
+  This algorithm takes as input a <a spec=infra>string</a> |fragment directive
+  input|, that is the raw text of the fragment directive and a [=Document=]
+  |document| over which it operates. It returns a <a spec=infra>list</a> of
+  {{Range}}s that are to be visually indicated, the first of which may be
+  scrolled into view (if the UA scrolls automatically).
+</div>
+
+1. If |fragment directive input| does not match the [=FragmentDirective=]
+   production, then return an empty <a spec=infra>list</a>.
 2. Let <em>directives</em> be a <a spec=infra>list</a> of <a spec=infra>string</a>s
-    that is the result of [=strictly split a string|strictly splitting the string=]
-    <em>fragment directive input</em> on "&".
-3. Let <em>ranges</em> be a <a spec=infra>list</a> of {{Range}}s that is
-    initially empty.
-4. For each <a spec=infra>string</a> <em>directive</em> in <em>directives</em>:
-    1. If <em>directive</em> does not match the production [=TextDirective=],
-        then continue.
-    2. If the result of [[#find-a-matching-range]] on <em>directive</em> is
-        non-null, then <a spec=infra for=list>append</a> it to <em>ranges</em>.
-5. Return <em>ranges</em>.
+   that is the result of [=strictly split a string|strictly splitting the string=]
+   |fragment directive input| on "&".
+3. Let |ranges| be a <a spec=infra>list</a> of {{Range}}s, initially empty.
+4. For each <a spec=infra>string</a> |directive| of |directives|:
+    1. If |directive| does not match the production [=TextDirective=],
+       then [=iteration/continue=].
+    1. Let |parsed values| be the result of running the [=parse a text
+       directive=] steps on |directive|.
+    1. If |parsed values| is null then [=iteration/continue=].
+    1. Let |prefix|, |textStart|, |textEnd|, and |suffix| be the values of the
+       equivalent items in |parsed values|.
+    1. If the result of running [=find range from a text directive=] on |prefix|,
+       |textStart|, |textEnd|, |suffix|, |document| is non-null, then
+       [=list/append=] it to |ranges|.
+5. Return |ranges|.
 
-### Parse a text directive ### {#parse-a-text-directive}
+To <dfn>find range from a text directive</dfn>, run the following steps:
+
+<div class="note">
+  This algorithm takes as input four strings: |prefix|, |textStart|, |textEnd|,
+  and |suffix| and a [=Document=] |document| in which to search. It returns a
+  {{Range}} that points to a the first text passage within the document that
+  matches the searched-for text and satisfies the surrounding context. Returns
+  null if no such passage exists.
+
+  See [[#syntax]] for a description of how these parameters are interpreted.
+
+  |textEnd| is optional. If omitted, this is an "exact" search and the returned
+  {{Range}} must contain a string exactly matching |textStart|. If |textEnd| is
+  provided, this is a "range" search; the returned {{Range}} must start with
+  |textStart| and end with |textEnd|. In the normative text below, we'll call a
+  text passage that matches the provided |textStart| and |textEnd|, regardless
+  of which mode we're in, the "matching text".
+
+  |prefix| and |suffix| are both optional, either or both may be omitted, in
+  which case context on that side of a match is not checked. e.g. If |prefix|
+  is null, text is matched without any requirement on what text precedes it.
+</div>
+
+1. Let |searchRange| be a {{Range}} with [=range/start=] (|document|, 0) and
+   [=range/end=] (|document|, |document|'s [=node/length=])
+1. While |searchRange| is not [=range/collapsed=]:
+    1. Let |potentialMatch| be null.
+    1. If |prefix| is not null:
+        1. Let |prefixMatch| be the {{Range}} representing the first instance
+           of |prefix| in |searchRange| by running the [=find a string in
+           range=] steps.
+        1. If |prefixMatch| is null, return null.
+        1. Set |searchRange|'s [=range/start=] to |prefixMatch|'s [=range/end=].
+        1. Advance |searchRange|'s [=range/start=] to the
+           [=next non-whitespace position=].
+        1. If |searchRange| is [=range/collapsed=] return null.
+           <div class="note">
+             This can happen if |prefix|'s [=range/end=] or its subsequent
+             non-whitespace position is at the end of the document.
+           </div>
+        1. [=/assert=]: |searchRange|'s [=range/start node=] is a {{Text}} node.
+           <div class="note">
+             |searchRange|'s [=range/start=] now points to the next
+             non-whitespace text data following a matched prefix.
+           </div>
+        1. Set |potentialMatch| to the {{Range}} representing the first
+           instance of a matching text in |searchRange| by following the
+           [=find a string in range=] steps
+           searching for |textStart|, |textEnd|.
+        1. If |potentialMatch| is null or its [=range/start=] is not
+           |searchRange|'s [=range/start=], [=iteration/continue=].
+           <div class="note">
+             In this case, we found a prefix but it was followed by something
+             other than a matching text so we'll continue searching for the
+             next instance of |prefix|.
+           </div>
+    1. Otherwise:
+        1. Set |potentialMatch| to the {{Range}} representing the first
+           instance of a matching text in |searchRange| by following the
+           [=find a string in range=] steps
+           searching for |textStart|, |textEnd|.
+        1. If |potentialMatch| is null, return null.
+        1. Set |searchRange|'s [=range/start=] to |potentialMatch|'s
+           [=range/end=].
+    1. [=/assert=]: |potentialMatch| is non-null, not [=range/collapsed=] and
+       represents a range exactly containing an instance of matching text.
+    1. If |suffix| is null, return |potentialMatch|.
+    1. Let |suffixRange| be a {{Range}} with [=range/start=] equal to
+       |potentialMatch|'s [=range/end=] and [=range/end=] equal to |search
+       range|'s [=range/end=].
+    1. Advance |suffixRange|'s [=range/start=] to the [=next non-whitespace
+       position=].
+    1. Let |suffix match| be the {{Range}} representing the first
+       instance of |suffix| in |suffixRange| by following the
+       [=find a string in range=] steps.
+    1. If |suffix match| is null then return null
+       <div class="note">
+         If the suffix doesn't appear in the remaining text of the document,
+         there's no possible way to make a match.
+       </div>
+    1. If |suffix match|'s [=range/start=] is |suffixRange|'s [=range/start=],
+       return |potentialMatch|
+
+To advance a {{Range}} |range|'s [=range/start=] to the <dfn>next
+non-whitespace position</dfn> follow the steps:
+
+1. While |range| is not collapsed:
+    1. Let |node| be |range|'s [=range/start node=]
+    1. Let |offset| be |range|'s [=range/start offset=]
+    1. If |node| is part of a [=non-searchable subtree=] then:
+        1. Set |range|'s [=range/start node=] to the next node, in
+           [=shadow-including tree order=], that isn't a [=shadow-including
+           descendant=] of |node|
+        1. [=iteration/continue=].
+    1. If |node| is not a [=visible text node=]:
+        1. Set |range|'s [=range/start node=] to the next node, in
+           [=shadow-including tree order=]
+        1. [=iteration/continue=].
+    1. If the [=Text/substring data=] of |node| at offset |offset|
+       and length 6 is equal to the string "&amp;nbsp;" then:
+        1. Add 6 to |range|'s [=range/start offset=].
+    1. Otherwise, if the [=Text/substring data=] of |node| at offset |offset|
+       and length 5 is equal to the string "&amp;nbsp" then:
+        1. Add 5 to |range|'s [=range/start offset=].
+    1. Otherwise:
+        1. Let |cp| be the [=code point=] at the |offset| index in |node|'s
+           [=CharacterData/data=].
+        1. If |cp| does not have the <a
+           href="http://www.unicode.org/reports/tr44/#White_Space">White_Space</a>
+           property set, return.
+           <div class="note">
+             For ASCII characters this is the set: U+0020 SPACE, U+0009 TAB,
+             U+000A LF, U+000B VT, U+000C FF, U+000D CR.
+           </div>
+        1. Add 1 to |range|'s [=range/start offset=].
+    1. If |range|'s [=range/start offset=] is equal to |node|'s
+       [=node/length=], set |range|'s [=range/start node=] to the next node in
+       [=shadow-including tree order=].
+
+To <dfn>find a string in range</dfn> for a <a spec=infra>string</a> |query|
+in a given {{Range}} |range|, run these steps:
+
+<div class="note">
+  This algorithm takes as input a <a spec=infra>string</a> |query| and a
+  {{Range}} |range|. It will return a {{Range}} that represents the first
+  [=word bounded=] instance within |range| of the |query| text. Returns null if
+  none is found.
+</div>
 
 <div class="note">
   <p>
-    This algorithm takes a single text directive string as input (e.g.
-    "text=prefix-,foo,bar") and attempts to parse the string into the
-    components of the directive (e.g. "prefix", "foo", "bar"). See [[#syntax]]
-    for the what each of these components means and how they're used.
+    The basic premise of this algorithm is to walk all searchable text nodes
+    within a block, collecting them into a list. The list is then concatenated
+    into a single string in which we can search, using the node list to
+    determine offsets with a node so we can return a {{Range}}.
   </p>
+
   <p>
-    Returns null if the input is invalid or fails to parse in any way.
-    Otherwise, returns a <a spec=infra>struct</a> containing four strings:
-    <em>textStart</em>, <em>textEnd</em>, <em>prefix</em>, <em>suffix</em>.
-    Only <em>textStart</em> is required to be non-null as the other parameters
-    are optional and may be omitted in a valid text directive string.
+    Collection breaks when we hit a block node, e.g. searching over this tree:
+
+    ```
+      <div>
+        a<em>b</em>c<div>d</div>e
+      </div>
+    ```
   </p>
+
+  Will perform a search on "abc", then on "c", then on "e".
 </div>
 
-1. Let |raw target text| be the substring of <em>text directive
-   input</em> starting at index 5.
+1. While |searchRange| is not [=range/collapsed=]:
+    1. Let |curNode| be |searchRange|'s [=range/start node=].
+    1. If |curNode| is part of a [=non-searchable subtree=]:
+        1. Set |searchRange|'s [=range/start node=] to the next node, in
+           [=shadow-including tree order=], that isn't a [=shadow-including
+           descendant=] of |curNode|.
+        1. [=iteration/continue=].
+    1. If |curNode| is not a [=visible text node=]:
+        1. Set |searchRange|'s [=range/start node=] to the next node, in
+           [=shadow-including tree order=].
+        1. [=iteration/continue=].
+    1. Otherwise:
+        1. Let |blockAncestor| be the [=nearest block ancestor=] of
+           |curNode|.
+        1. Let |textNodeList| be a <a spec=infra>list</a> of {{Text}} nodes,
+           initially empty.
+        1. While |curNode| is a [=shadow-including descendant=] of
+           |blockAncestor| and it does not [=tree/following|follow=]
+           |searchRange|'s [=range/end node=]:
+            1. If |curNode| [=has block-level display=] then
+               [=iteration/break=].
+            1. If |curNode| is [=search invisible=]:
+                1. Set |curNode| to the next node in [=shadow-including tree
+                   order=] whose ancestor is not |curNode|
+                2. [=iteration/continue=].
+            1. If |curNode| is a [=visible text node=] then append it to
+               |textNodeList|.
+            1. Set |curNode| to the next node in [=shadow-including tree
+               order=].
+        1. Run the [=find a range from a node list=] steps given |query|,
+           |searchRange|, and |textNodeList|, as input. If the resulting
+           {{Range}} is not null, then return it.
+        1. [=/assert=]: |curNode| [=tree/following|follows=] |searchRange|'s
+           [=range/start node=].
+        1. Set |searchRange|'s [=range/start=] to the [=/boundary point=]
+           (|curNode|, 0).
+1. Return null
+
+A node is <dfn>search invisible</dfn> if it is an {{HTMLElement}} and meets any
+of the following conditions:
+1. The [=computed value=] of its 'display' property is 'none'
+1. It has a [=Element/local name=] equal to any of the following: "area",
+   "base", "basefont", "bgsound", "br", "col", "embed", "frame", "hr", "img",
+   "keygen", "link", "menuitem", "meta", "param", "source", "track", "wbr"
+1. Is any of the following types: {{HTMLIFrameElement}}, {{HTMLImageElement}},
+   {{HTMLMeterElement}}, {{HTMLObjectElement}}, {{HTMLProgressElement}},
+   {{HTMLStyleElement}}, {{HTMLScriptElement}}, {{HTMLVideoElement}},
+   {{HTMLAudioElement}}
+1. Is an {{HTMLSelectElement}} whose {{HTMLSelectElement/multiple}} attribute
+   is false.
+
+A node is part of a <dfn>non-searchable subtree</dfn> if it is or has an
+ancestor that is [=search invisible=].
+
+A node is a <dfn>visible text node</dfn> if it is a {{Text}} node, the
+[=computed value=] of its 'visibility' property is 'visible', and it is <a
+spec=html>being rendered</a>.
+
+A node <dfn>has block-level display</dfn> if the [=computed value=] of its
+'display' property is any of 'block', 'table', 'flow-root', 'grid', 'flex',
+'list-item'.
+
+To find the <dfn>nearest block ancestor</dfn> of a |node| follow the steps:
+1. While |node| is non-null
+    1. If |node| is not a {{Text}} node and it [=has block-level display=] then
+       return |node|.
+    1. Otherwise, set |node| to |node|'s [=tree/parent=].
+1. Return |node|'s [=Node/node document=]'s [=document element=]
+
+To <dfn>find a range from a node list</dfn> given a search string
+|queryString|, a {{Range}} |searchRange|, and a [=/list=] of {{Node}}s |nodes|,
+follow the steps
+
+<div class="note">
+  This will only return a match if the matched text falls on word boundaries.
+  That is, the text match must begin and end on a word boundary. For example:
+
+  <div class="example">
+    “range” will match in “mountain range” but not in “color orange” nor
+    “forest ranger”.
+  </div>
+
+  See [[#word-boundaries]] for details and more examples.
+</div>
+
+1. [=/assert=]: each item in |nodes| is a {{Text}} node.
+1. Let |searchBuffer| be the [=string/concatenate|concatenation=] of the
+   [=CharacterData/data=] field of each item in in |nodes|.
+1. Let |searchStart| be 0
+1. If the first item in |nodes| is |searchRange|'s [=range/start node=] then
+   set |searchStart| to |searchRange|'s [=range/start offset=].
+1. Let |start|, |end| be [=/boundary point=]s, initially null.
+1. Let |matchIx| be null.
+1. While |matchIx| is null
+    1. Let |matchIx| be the first [=string/position variable=] in |searchBuffer|, greater
+       than or equal to |searchStart|, where |queryString| occurs. That is, for each
+       [=string/position variable=] |j| in |searchRange|, the |j|th code point in
+       |queryString| is equal to the (|matchIx|+|j|)th code point in |searchBuffer|. If no
+       such |matchIx| exists, return null.
+       <div class="note">
+         In plain language: find the index of the first instance of |queryString|
+         in |searchBuffer|, starting at |searchStart|.
+       </div>
+    1. Let |endIx| be |matchIx| + |queryString|'s [=string/length=].
+       <div class="note">
+          |endIx| is the index of the last character in the match + 1.
+       </div>
+    1. Set |start| be the [=/boundary point=] result of [=get boundary point at
+       index=] |matchIx| run over |nodes| with |isEnd| false.
+    1. Set |end| be the [=/boundary point=] result of [=get boundary point at
+       index=] |endIx| run over |nodes| with |isEnd| true.
+    1. If the substring of |searchBuffer| starting at |matchIx| and of length
+       |queryString|'s [=string/length=] is not [=word bounded=], given the <a
+       spec=html>language</a> from each of |start| and |end|'s [=boundary
+       point/node=]s as the |startLocale| and |endLocale|:
+         1. Let |searchStart| be |matchIx| + 1.
+         1. Set |matchIx| to null.
+1. Let |endInset| be 0.
+1. If the last item in |nodes| is |searchRange|'s [=range/end node=] then set
+   |endInset| to (|searchRange|'s [=range/end node=]'s [=node/length=] -
+   |searchRange|'s [=range/end offset=])
    <div class="note">
-     This is the remainder of the <em>text directive input</em> following,
-     but not including, the "text=" prefix.
+     |endInset| is the offset from the last position in the last node in the
+     reverse direction. Alternatively, it is the length of the node that's not
+     included in the range.
    </div>
-1. Let <var>tokens</var> be a <a for=/>list</a> of strings that is the result of
-   <a lt="split on commas">splitting |raw target text| on commas</a>.
-1. If <var>tokens</var> has size less than 1 or greater than 4, return null.
-1. If any of <var>tokens</var>' items are the empty string, return null.
-1. Let <var>retVal</var> be a <a spec=infra>struct</a> consisting of four strings:
-   <em>textStart</em>, <em>textEnd</em>, <em>prefix</em> and
-   <em>suffix</em>, each initialized to null.
-1. Let <var>potential prefix</var> be the first item of <var>tokens</var>.
-1. If the last character of <em>potential prefix</em> is U+002D (-), then:
-   1. Set <em>retVal.prefix</em> to the result of removing the last character from
-      <em>potential prefix</em>.
-   1. <a spec=infra for=list>Remove</a> the first item of the list <var>tokens</var>.
-1. Let <em>potential suffix</em> be the last item of <var>tokens</var>, if one exists.
-1. If the first character of <em>potential suffix</em> is U+002D (-), then:
-    1. Set <em>retVal.suffix</em> to the result of removing the first character from
-       <em>potential suffix</em>.
-    1. <a spec=infra for=list>Remove</a> the last item of the list <var>tokens</var>.
-1. If <var>tokens</var> has <a spec=infra for=list>size</a> not equal to 1 nor 2 then
-   return null.
-1. Let <em>retVal.textStart</em> be the first item of <var>tokens</var>.
-1. If <var>tokens</var> has <a spec=infra for=list>size</a> 2, then let
-   <em>retVal.textEnd</em> be the last item of <var>tokens</var>.
-1. Return <var>retVal</var>
+1. If |matchIx| + |queryString|'s [=string/length=] is greater than or equal to
+   |searchBuffer|'s length - |endInset| return null.
+   <div class="note">
+     If the match runs past the end of the search range, return null.
+   </div>
+1. [=/assert=]: |start| and |end| are non-null, valid [=/boundary point=]s in
+   |searchRange|.
+1. Return a {{Range}} with [=range/start=] |start| and [=range/end=] |end|.
 
-### Find a matching Range ### {#find-a-matching-range}
+To <dfn>get boundary point at index</dfn>, given a [=string/position variable=]
+|index|, [=/list=] of {{Text}} nodes |nodes|, and a boolean |isEnd|, follow
+these steps:
 
 <div class="note">
   <p>
-    This algorithm takes a single <a spec=infra>string</a> |directive| as
-    input (e.g.  "text=prefix-,foo,bar") and returns the first {{Range}} in the
-    {{Document}} that corresponds to the match string(s) in the text directive
-    and satisfies the prefix and suffix (if given).  Returns null if no such
-    {{Range}} exists.
+    This is a small helper routine used by the steps above to determine which
+    node a given index in the concatenated string belongs to.
+  </p>
+  <p>
+    |isEnd| is used to differentiate start and end indices. An end index points
+    to the "one-past-last" character of the matching string. If the match ends
+    at node boundary, we want the end offset to remain within that node, rather
+    than the start of the next node.
   </p>
 </div>
 
-To find the target text for a given string |directive|, the user agent must run
-these steps:
-1. If |directive| does not begin with the string "text=",
-   then return null.
-1. Let |parsed values| be the result of running
-   [[#parse-a-text-directive]] on |directive|.
-1. If |parsed values| is null, return null.
-1. Let |prefix|, |textStart|, |textEnd|, and |suffix| be the values of the
-   equivalent items in |parsed values|.
-1. Let |walker| be a {{TreeWalker}} equal to
-   {{Document/createTreeWalker()|document.createTreeWalker()}}.
-1. Let |position| be a <a spec=infra for=string>position variable</a>
-   that indicates a text offset in <em>walker.currentNode.innerText</em>.
-1. If |textEnd| is null, then:
-     1. Let |match position| be the result of [[#find-match-with-context]]
-        with input walker |walker|, search position |position|,
-        prefix |prefix|, query |textStart|, and suffix |suffix|.
-     1. If |match position| is null, return null.
-     1. Let |match| be a {{Range}} in <em>walker.currentNode</em> with
-        position |match position| and length equal to the <a spec=infra
-        for=string>length</a> of |textStart|.
-     1. Return |match|.
-1. Otherwise, let |potential start position| be the result of
-   [[#find-match-with-context]] with input walker |walker|, start position
-   |position|, prefix |prefix|, query |textStart|, and suffix |null|.
-1. If |potential start position| is null, then return null.
-1. Let |end position| be the result of [[#find-match-with-context]] with input
-   walker |walker|, search position |potential start position|, prefix |null|,
-   query |textEnd|, and suffix |suffix|.
-1. If |end position| is null, then return null.
-1. Advance |end position| by the length of |textEnd|.
-1. Let |match| be a {{Range}} in <em>walker.currentNode</em> with start
-   position |potential start position| and length equal to |end position| - |start
-   position|.
-1. Return |match|.
+1. Let |counted| be 0.
+1. For each |curNode| of |nodes|:
+    1. Let |nodeEnd| be |counted| + |curNode|'s [=node/length=].
+    1. If |isEnd| is true, add 1 to |nodeEnd|.
+    1. If |nodeEnd| is greater than |index| then:
+        1. Return the [=/boundary point=] (|curNode|, |index| - |counted|).
+    1. Increment |counted| by |curNode|'s [=node/length=].
+1. Return null.
 
-### Find an exact match with context ### {#find-match-with-context}
-
+### Word Boundaries ### {#word-boundaries}
 <div class="note">
-  This algorithm has input |walker|, |search position|, |prefix|, |query|, and
-  |suffix| and returns a text position that is the start of the match.
+  Limiting matching to word boundaries is one of the mitigations to limit
+  cross-origin information leakage.
 </div>
 <div class="note">
-  The input |walker| is a {{TreeWalker}} reference, not a copy, i.e. any
-  modifications are performed on the caller's instance of |walker|.
-</div>
-
-1. While <em>walker.currentNode</em> is not null:
-    1. Assert: <em>walker.currentNode</em> is a text node.
-    2. Let |text| be equal to <em>walker.currentNode.innerText</em>.
-    3. While |search position| does not point past the end of
-        |text|:
-        1. If |prefix| is not null, then:
-            1. Advance |search position| to the position after the result
-                of [[#next-word-bounded-instance]] of |prefix| in
-                |text| from |search position| with [=current
-                locale=].
-            2. If |search position| is null, then break.
-            3. <a spec=infra>Skip ASCII whitespace</a> on |search
-                position|.
-            4. If |search position| is at the end of |text|, then:
-                1. Perform [[#advance-walker-to-text]] on |walker|.
-                2. If <em>walker.currentNode</em> is null, then return null.
-                3. Set |text| to <em>walker.currentNode.innerText</em>.
-                4. Set |search position| to the beginning of
-                    |text|.
-                5. <a spec=infra>Skip ASCII whitespace</a> on |search
-                    position|.
-            5. If the result of [[#next-word-bounded-instance]] of
-                |query| in |text| from |search position|
-                with [=current locale=] does not start at |search
-                position|, then continue.
-        2. Advance |search position| to the position after the result of
-            [[#next-word-bounded-instance]] of |query| in |text|
-            from |search position| with [=current locale=].
-            <div class="note">
-              If a prefix was specified, the search position is at the
-              beginning of |query| and this will advance it to the end
-              of the query to search for a potential suffix. Otherwise, this
-              will find the next instance of query.
-            </div>
-        3. If |search position| is null, then break.
-        4. Let |potential match position| be a
-            <a spec=infra for=string>position variable</a> equal to |search
-            position| minus the length of |query|.
-        5. If |suffix| is null, then return |potential
-            match position|.
-        6. <a spec=infra>Skip ASCII whitespace</a> on |search position|.
-        7. If |search position| is at the end of |text|, then:
-            1. Let |suffix_walker| be a {{TreeWalker}} that is a copy of
-                |walker|.
-            2. Perform [[#advance-walker-to-text]] on |suffix_walker|.
-            3. If <em>suffix_walker.currentNode</em> is null, then return null.
-            4. Set |text| to
-                <em>suffix_walker.currentNode.innerText</em>.
-            5. Set |search position| to the beginning of |text|.
-            6. <a spec=infra>Skip ASCII whitespace</a> on |search
-                position|.
-        8. If the result of [[#next-word-bounded-instance]] of |suffix|
-            in |text| from |search position| with [=current
-            locale=] starts at |search position|, then return
-            |potential match position|.
-    4. Perform [[#advance-walker-to-text]] on |walker|.
-2. Return null.
-
-The <dfn>current locale</dfn> is the <a spec=html>language</a> of the
-|currentNode|.
-
-### Advance a TreeWalker to the next text node ### {#advance-walker-to-text}
-<div class="note">
-  The input <em>walker</em> is a {{TreeWalker}} reference, not a
-  copy, i.e. any modifications are performed on the caller's instance of
-  <em>walker</em>.
-</div>
-
-1. While the input <em>walker.currentNode</em> is not null and
-    <em>walker.currentNode</em> is not a text node:
-    1. Advance the current node by calling {{TreeWalker/nextNode()|walker.nextNode()}}.
-
-### Find the next word bounded instance ### {#next-word-bounded-instance}
-<div class="note">
-This algorithm has input |query|, |text|, |start position|, and |locale| and
-returns a Range that specifies the word bounded text instance if it is found.
-</div>
-<div class="note">
-Limiting matching to word boundaries is one of the mitigations to limit
-cross-origin information leakage.
-</div>
-<div class="note">
-See
-<a href="https://github.com/tc39/proposal-intl-segmenter">Intl.Segmenter</a>,
-a proposal to specify unicode segmentation, including word segmentation. Once
-specified, this algorithm may be improved by making use of the Intl.Segmenter
-API for word boundary matching.
+  See <a
+  href="https://github.com/tc39/proposal-intl-segmenter">Intl.Segmenter</a>, a
+  proposal to specify unicode segmentation, including word segmentation. Once
+  specified, this algorithm may be improved by making use of the Intl.Segmenter
+  API for word boundary matching.
 </div>
 
 <p>
@@ -791,17 +1006,58 @@ API for word boundary matching.
   alphabet as valid, one-letter words.
 </p>
 
-1. While |start position| does not point past the end of |text|:
-    1. Advance |start position| to the next instance of |query| in |text|.
-    2. Let |range| be a Range with position |start position| and length equal to
-        the length of |query|.
-    3. Using locale |locale|, let |left bound| be the last word boundary in
-        |text| before |range|.
-    4. Using locale |locale|, let |right bound| be the first word boundary in
-        |text| after |range|.
-    5. If |left bound| immediately precedes |range| and |right bound|
-        immediately follows |range|, then return |range|.
-2. Return null.
+To determine if a substring of a larger string is <dfn>word bounded</dfn>,
+follow these steps:
+
+<div class="note">
+  This algorithm takes as input a <a spec=infra>string</a> |text|, a
+  [=string/position variable=] |start position| and number |count|; representing
+  a substring in |text|, as well as a |startLocale| and |endLocale| specifying
+  the language of the string at each end of the match.
+
+  |start position| and |count| are assumed to be valid in that they represent a
+  substring within the bounds of |text|.
+
+  Returns true if the substring is word bounded, false otherwise.
+</div>
+
+<div class="note">
+  Intuitively, a substring is word bounded if it neither begins nor ends in the
+  middle of a word.
+
+  In languages with a word separator (e.g. " " space) this is (mostly)
+  straightforward; though there are details covered by the above technical
+  reports such as new lines, hyphenations, quotes, etc.
+
+  Some languages do not have such a separator (notably,
+  Chinese/Japanese/Korean). Languages such as these requires dictionaries to
+  determine what a valid word in the given locale is.
+</div>
+
+1. Using locale |startLocale|, let |left bound| be the last word boundary in
+   |text| that precedes |start position|th [=code point=] of |text|.
+   <div class="note">
+     A string will always contain at least 2 word boundaries before the first
+     code point and after the last code point of the string.
+   </div>
+1. If the first [=code point=] of |text| following |left bound| is not at
+   position |start position| return false.
+1. Let |end position| be (|start position| + |count| - 1).
+1. Using locale |endLocale|, let |right bound| be the first word boundary in
+   |text| after the |end position|th [=code point=].
+1. If the first [=code point=] of |text| preceding |right bound| is not at
+   position |end position| return false.
+1. Return true.
+
+<div class="example">
+  The substring "mountain range" is word bounded within the string "An impressive
+  mountain range" but not within "An impressive mountain ranger".
+</div>
+
+<div class="example">
+  In the Japanese string "ウィキペディアへようこそ" (Welcome to Wikipedia),
+  "ようこそ" (Welcome) is considered word-bounded but "ようこ" is not.
+</div>
 
 ## Indicating The Text Match ## {#indicating-the-text-match}
 
@@ -894,7 +1150,7 @@ still be derived from the URL itself.
 </div>
 
 Range-based matches can be helpful when the quoted text is excessively long
-and encoding the entire string would produce an unwieldly URL.
+and encoding the entire string would produce an unwieldy URL.
 
 It is recommended that text snippets shorter than 300 characters always be
 encoded using an exact match. Above this limit, the UA should encode the string

--- a/index.html
+++ b/index.html
@@ -1222,7 +1222,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version ae6def1cbca03b321b2ad730ac2f51eeba21ed81" name="generator">
+  <meta content="Bikeshed version 5721fde7f6b8111f662b83b678f9e181a9838206" name="generator">
   <link href="wicg.github.io/ScrollToTextFragment/index.html" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1470,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-19">19 February 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-28">28 February 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1548,12 +1548,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <a href="#navigating-to-text-fragment"><span class="secno">3.5</span> <span class="content">Navigating to a Text Fragment</span></a>
        <ol class="toc">
         <li><a href="#scroll-rect-into-view"><span class="secno">3.5.1</span> <span class="content">Scroll a DOMRect into view</span></a>
-        <li><a href="#find-text-matches"><span class="secno">3.5.2</span> <span class="content">Find text matches</span></a>
-        <li><a href="#parse-a-text-directive"><span class="secno">3.5.3</span> <span class="content">Parse a text directive</span></a>
-        <li><a href="#find-a-matching-range"><span class="secno">3.5.4</span> <span class="content">Find a matching Range</span></a>
-        <li><a href="#find-match-with-context"><span class="secno">3.5.5</span> <span class="content">Find an exact match with context</span></a>
-        <li><a href="#advance-walker-to-text"><span class="secno">3.5.6</span> <span class="content">Advance a TreeWalker to the next text node</span></a>
-        <li><a href="#next-word-bounded-instance"><span class="secno">3.5.7</span> <span class="content">Find the next word bounded instance</span></a>
+        <li><a href="#finding-ranges-in-a-document"><span class="secno">3.5.2</span> <span class="content">Finding Ranges in a Document</span></a>
+        <li><a href="#word-boundaries"><span class="secno">3.5.3</span> <span class="content">Word Boundaries</span></a>
        </ol>
       <li><a href="#indicating-the-text-match"><span class="secno">3.6</span> <span class="content">Indicating The Text Match</span></a>
       <li><a href="#feature-detectability"><span class="secno">3.7</span> <span class="content">Feature Detectability</span></a>
@@ -1677,8 +1673,8 @@ translation-hints or enabling accessibility features.</p>
    <h4 class="heading settled" data-level="3.3.1" id="parsing-the-fragment-directive"><span class="secno">3.3.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
    <p>To the definition of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>, add:</p>
    <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is either
-null or an ASCII string holding data used by the UA to process the resource. It
-is initially null. </em></p>
+  null or an ASCII string holding data used by the UA to process the resource. It
+  is initially null. </em></p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-delimiter">fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> is part of the URL fragment. This means it must
@@ -1732,10 +1728,68 @@ web-exposed)</p>
    <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
 the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> is the string
 "text=foo". </div>
+   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parse-a-text-directive">parse a text directive</dfn>, on a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a> <var>string</var>,
+run these steps:</p>
+   <div class="note" role="note">
+    <p> This algorithm takes a single text directive string as input (e.g.
+    "text=prefix-,foo,bar") and attempts to parse the string into the
+    components of the directive (e.g. ("prefix", "foo", "bar", null)). See <a href="#syntax">§ 3.2 Syntax</a> for the what each of these components means and how they’re
+    used. </p>
+    <p> Returns null if the input is invalid or fails to parse in any way.
+    Otherwise, returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct">struct</a> containing four strings: <var>textStart</var>, <var>textEnd</var>, <var>prefix</var>, <var>suffix</var>.
+    Only <var>textStart</var> is required to be non-null as the other parameters
+    are optional and may be omitted in a valid text directive string. </p>
+   </div>
+   <ol>
+    <li data-md>
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">assert</a>: <var>raw target text</var> matches the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a>.</p>
+    <li data-md>
+     <p>Let <var>raw target text</var> be the substring of <var>text directive
+   input</var> starting at index 5.</p>
+     <div class="note" role="note"> This is the remainder of the <var>text directive input</var> following,
+ but not including, the "text=" prefix. </div>
+    <li data-md>
+     <p>Let <var>tokens</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of strings that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <var>raw target text</var> on commas</a>.</p>
+    <li data-md>
+     <p>If <var>tokens</var> has size less than 1 or greater than 4, return null.</p>
+    <li data-md>
+     <p>If any of <var>tokens</var>’ items are the empty string, return null.</p>
+    <li data-md>
+     <p>Let <var>retVal</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct①">struct</a> consisting of four strings: <var>textStart</var>, <var>textEnd</var>, <var>prefix</var> and <var>suffix</var>, each initialized to null.</p>
+    <li data-md>
+     <p>Let <var>potential prefix</var> be the first item of <var>tokens</var>.</p>
+    <li data-md>
+     <p>If the last character of <var>potential prefix</var> is U+002D (-), then:</p>
+     <ol>
+      <li data-md>
+       <p>Set <em>retVal.prefix</em> to the result of removing the last character from <var>potential prefix</var>.</p>
+      <li data-md>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> the first item of the list <var>tokens</var>.</p>
+     </ol>
+    <li data-md>
+     <p>Let <var>potential suffix</var> be the last item of <var>tokens</var>, if one exists.</p>
+    <li data-md>
+     <p>If the first character of <var>potential suffix</var> is U+002D (-), then:</p>
+     <ol>
+      <li data-md>
+       <p>Set <em>retVal.suffix</em> to the result of removing the first character from <var>potential suffix</var>.</p>
+      <li data-md>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove①">Remove</a> the last item of the list <var>tokens</var>.</p>
+     </ol>
+    <li data-md>
+     <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> not equal to 1 nor 2 then
+   return null.</p>
+    <li data-md>
+     <p>Let <em>retVal.textStart</em> be the first item of <var>tokens</var>.</p>
+    <li data-md>
+     <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size①">size</a> 2, then let <em>retVal.textEnd</em> be the last item of <var>tokens</var>.</p>
+    <li data-md>
+     <p>Return <var>retVal</var></p>
+   </ol>
    <h4 class="heading settled" data-level="3.3.2" id="fragment-directive-grammar"><span class="secno">3.3.2. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
     A <dfn data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive<a class="self-link" href="#valid-fragment-directive"></a></dfn> is a sequence of characters that appears
 in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a> that matches the production: 
-   <dl> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirective">FragmentDirective</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> | <a data-link-type="dfn" href="#unknowndirective" id="ref-for-unknowndirective">UnknownDirective</a>) ("&amp;" <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective">FragmentDirective</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="unknowndirective">UnknownDirective</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#characterstring" id="ref-for-characterstring">CharacterString</a></dd></code> </dl>
+   <dl> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirective">FragmentDirective</dfn> ::=</dt> <dd>(<a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a> | <a data-link-type="dfn" href="#unknowndirective" id="ref-for-unknowndirective">UnknownDirective</a>) ("&amp;" <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective">FragmentDirective</a>)?</dd></code> <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="unknowndirective">UnknownDirective</dfn> ::=</dt> <dd><a data-link-type="dfn" href="#characterstring" id="ref-for-characterstring">CharacterString</a></dd></code> </dl>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective②">FragmentDirective</a> may contain multiple directives split by the "&amp;"
 character. Currently this means we allow multiple text directives to enable
 multiple indicated strings in the page, but this also allows for future
@@ -1769,7 +1823,7 @@ enables specifying a piece of text on the page, that matches the production:</p>
     <code> </code>
     <p></p>
     <div class="note" role="note"> A <a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar①">ExplicitChar</a> may be any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points">URL code point</a> that
-is not explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a> syntax, that is "&amp;", "-", and
+is not explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a> syntax, that is "&amp;", "-", and
 ",", which must be percent-encoded. </div>
      <code><dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar">PercentEncodedChar</dfn> ::=</dt><dd>"%" [a-zA-Z0-9]+</dd></code> 
    </dl>
@@ -1793,7 +1847,7 @@ information to the page.</p>
   condition. This information must not be shared with the page. </div>
    <div class="note" role="note"> TODO: This last paragraph and example are probably not be necessary - the
   page can already determine what the user is looking at based on the viewport
-  rect. It may not be desireable since it would prevent use cases like
+  rect. It may not be desirable since it would prevent use cases like
   marginalia, allowing pages to provide UA and linking based on the text
   fragment. </div>
    <p>The following subsections restrict the feature to mitigate the expected attack
@@ -1808,10 +1862,10 @@ can be a convenient experience for the user but does present some risks that
 implementing UAs should be aware of.</p>
    <p>There are known (and potentially unknown) ways a scroll on navigation might be
 detectable and distinguished from natural user scrolls.</p>
-   <div class="example" id="example-90534c84"><a class="self-link" href="#example-90534c84"></a> An origin embedded in an iframe in the target page registers an
+   <div class="example" id="example-fe268bc5"><a class="self-link" href="#example-fe268bc5"></a> An origin embedded in an iframe in the target page registers an
   IntersectionObserver and determines in the first 500ms of page load whether
   a scroll has occurred. This scroll can be indicative of whether the text
-  fragment was successfuly found on the page. </div>
+  fragment was successfully found on the page. </div>
    <div class="example" id="example-ce37442a"><a class="self-link" href="#example-ce37442a"></a> Two users share the same network on which traffic is visible between them.
   A malicious user sends the victim a link with a text fragment to a
   page. The searched-for text appears nearby to a resource located on a unique
@@ -1831,10 +1885,27 @@ navigating to a text fragment.</p>
 may, instead, provide UI to initiate the scroll ("click to scroll") or none
 at all. In these cases UA should provide some indication to the user that an
 indicated passage exists further down on the page.</p>
+   <p>The examples above illustrate that in specific circumstances, it may be
+possible for an attacker to extract 1 bit of information about content on the
+page.  However, care must be taken so that such opportunities cannot be
+exploited to extract arbitrary content from the page by repeating the attack.
+For this reason, restrictions based on user activation and browsing context
+isolation are very important and must be implemented.</p>
+   <div class="note" role="note">
+     Browsing context isolation ensures that no other document can script the
+  target document which helps reduce the attack surface. 
+    <p>However, it also ensures any malicious use is difficult to hide. A browsing
+  context that’s the only one in a group must be a top level browsing context
+  (i.e. a full tab/window).</p>
+   </div>
+   <p>If a UA does choose to scroll automatically, it must ensure no scrolling is
+performed while the document is in the background (for example, in an inactive
+tab). This ensures any malicious usage is visible to the user and prevents
+attackers from trying to secretly automate a search in background documents.</p>
    <h4 class="heading settled" data-level="3.4.3" id="search-timing"><span class="secno">3.4.3. </span><span class="content">Search Timing</span><a class="self-link" href="#search-timing"></a></h4>
    <p>A naive implementation of the text search algorithm could allow information
 exfiltration based on runtime duration differences between a matching and non-
-matching query. If an attacker were to find a way to synchronously navigate
+matching query. If an attacker could find a way to synchronously navigate
 to a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑤">text fragment directive</a>-invoking URL, they would be able to determine
 the existence of a text snippet by measuring how long the navigation call takes.</p>
    <div class="note" role="note"> The restrictions in <a href="#should-allow-text-fragment">§ 3.4.4 Should Allow Text Fragment</a> should prevent this
@@ -1843,7 +1914,7 @@ the existence of a text snippet by measuring how long the navigation call takes.
    <p>For this reason, the implementation <em>must ensure the runtime of <a href="#navigating-to-text-fragment">§ 3.5 Navigating to a Text Fragment</a> steps does not differ based on whether a match
 has been successfully found</em>.</p>
    <p>This specification does not specify exactly how a UA achieves this as there are
-multiple solutions with differing tradeoffs. For example, a UA <em>may</em> continue to walk the tree even after a match is found in <a href="#find-a-matching-range">§ 3.5.4 Find a matching Range</a>.  Alternatively, it <em>may</em> schedule an
+multiple solutions with differing tradeoffs. For example, a UA <em>may</em> continue to walk the tree even after a match is found in <a href="#text-directive-to-range"></a>.  Alternatively, it <em>may</em> schedule an
 asynchronous task to find and set the indicated part of the document.</p>
    <h4 class="heading settled" data-level="3.4.4" id="should-allow-text-fragment"><span class="secno">3.4.4. </span><span class="content">Should Allow Text Fragment</span><a class="self-link" href="#should-allow-text-fragment"></a></h4>
    <div class="note" role="note"> TODO: This should really only prevent potentially observable side-effects like
@@ -1943,32 +2014,33 @@ into view</a>, with <em>behavior</em> set to "auto", <em>block</em> set to "star
    <p>Add the following steps to the beginning of the processing model for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document" id="ref-for-the-indicated-part-of-the-document①">the indicated part of the document</a>:</p>
    <ol>
     <li data-md>
-     <p>Let <em>fragment directive string</em> be the <em>document</em>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment
-directive</a>.</p>
+     <p>Let <var>fragment directive string</var> be the <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a>.</p>
     <li data-md>
-     <p>If <em>document</em>’s <a href="#allow-text-fragment-directive-flag">§ 3.4.5 allowTextFragmentDirective flag</a> is true then:</p>
+     <p>If <var>document</var>’s <a href="#allow-text-fragment-directive-flag">§ 3.4.5 allowTextFragmentDirective flag</a> is true then:</p>
      <ol>
       <li data-md>
-       <p>Let <em>ranges</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> that is the result of <a href="#find-text-matches">§ 3.5.2 Find text matches</a> with <em>fragment directive string</em>.</p>
+       <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
+   the <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive">process a fragment directive</a> steps with <var>fragment directive
+   string</var> and <var>document</var>.</p>
       <li data-md>
-       <p>If <em>ranges</em> is non-empty, then:</p>
+       <p>If <var>ranges</var> is non-empty, then:</p>
        <ol>
         <li data-md>
-         <p>Let <em>range</em> be the first item of <em>ranges</em>.</p>
-         <div class="note" role="note"> The first <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range②">Range</a></code> in <em>ranges</em> is specifically
-scrolled into view. This <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range③">Range</a></code>, along with the
-remaining <em>ranges</em> should be visually indicated in a way that
-is not revealed to script, which is left as UA-defined behavior. </div>
+         <p>Let <var>range</var> be the first item of <var>ranges</var>.</p>
+         <div class="note" role="note"> The first <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range②">Range</a></code> in <var>ranges</var> is specifically
+ scrolled into view. This <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range③">Range</a></code>, along with the
+ remaining <var>ranges</var> should be visually indicated in a way that
+ is not revealed to script, which is left as UA-defined behavior. </div>
         <li data-md>
-         <p>Let <em>node</em> be <em>range</em>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-range-commonancestorcontainer" id="ref-for-dom-range-commonancestorcontainer">commonAncestorContainer</a></code>.</p>
+         <p>Let <var>node</var> be <var>range</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-range-commonancestorcontainer" id="ref-for-dom-range-commonancestorcontainer">commonAncestorContainer</a></code>.</p>
         <li data-md>
-         <p>While <em>node</em>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-nodetype" id="ref-for-dom-node-nodetype">nodeType</a></code> is not <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-element_node" id="ref-for-dom-node-element_node">ELEMENT_NODE</a></code>:</p>
+         <p>While <var>node</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-nodetype" id="ref-for-dom-node-nodetype">nodeType</a></code> is not <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-element_node" id="ref-for-dom-node-element_node">ELEMENT_NODE</a></code>:</p>
          <ol>
           <li data-md>
-           <p>Set <em>node</em> to <em>node</em>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-parentnode" id="ref-for-dom-node-parentnode">parentNode</a></code>.</p>
+           <p>Set <var>node</var> to <var>node</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-parentnode" id="ref-for-dom-node-parentnode">parentNode</a></code>.</p>
          </ol>
         <li data-md>
-         <p>The indicated part of the document is <em>node</em> and <em>range</em>; return.</p>
+         <p>The indicated part of the document is <var>node</var> and <var>range</var>; return.</p>
        </ol>
      </ol>
    </ol>
@@ -1996,250 +2068,419 @@ box</em> with options <em>options</em> and startingElement <em>element</em>.</p>
     <li data-md>
      <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view③">scroll a DOMRect into view</a> on <em>bounding rect</em> with <em>options</em> and startingElement <em>containingElement</em>.</p>
    </ol>
-   <h4 class="heading settled" data-level="3.5.2" id="find-text-matches"><span class="secno">3.5.2. </span><span class="content">Find text matches</span><a class="self-link" href="#find-text-matches"></a></h4>
-   <div class="note" role="note"> This algorithm has input <em>fragment directive input</em>, that is the raw
-  fragment directive <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, and returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑤">Range</a></code>s that are to be visually indicated, the
-  first of which should be scrolled into view. </div>
+   <h4 class="heading settled" data-level="3.5.2" id="finding-ranges-in-a-document"><span class="secno">3.5.2. </span><span class="content">Finding Ranges in a Document</span><a class="self-link" href="#finding-ranges-in-a-document"></a></h4>
+   <div class="note" role="note">
+     This section outlines several algorithms and definitions that specify how to
+  turn a full fragment directive string into a list of <code class="idl"><a data-link-type="idl">Ranges</a></code> in the
+  document. 
+    <p>At a high level, we take a fragment directive string that looks like this:</p>
+<pre>text=prefix-,foo&amp;unknown&amp;text=bar,baz
+</pre>
+    <p>We break this up into the individual text directives:</p>
+<pre>text=prefix-,foo
+text=bar,baz
+</pre>
+    <p>For each text directive, we perform a search in the document for the first
+  instance of rendered text that matches the restrictions in the directive.
+  Each search is independent of any others; that is, the result is the same
+  regardless of how many other directives are provided or their match result.</p>
+    <p>If a directive successfully matches to text in the document, it returns a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑤">Range</a></code> indicating that match in the document. The <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive①">process a fragment
+  directive</a> steps are the high level API provided by this section. These
+  return a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑥">Range</a></code>s that were matched by the
+  individual directive matching steps, in the order the directives were
+  specified in the fragment directive string.</p>
+    <p>If a directive was not matched, it does not add an item to the returned
+  list.</p>
+   </div>
+   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, run these steps:</p>
+   <div class="note" role="note"> This algorithm takes as input a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> <var>fragment directive
+  input</var>, that is the raw text of the fragment directive and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">Document</a> <var>document</var> over which it operates. It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑦">Range</a></code>s that are to be visually indicated, the first of which may be
+  scrolled into view (if the UA scrolls automatically). </div>
    <ol>
     <li data-md>
-     <p>If <em>fragment directive input</em> does not match the <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective③">FragmentDirective</a> production, then return an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>.</p>
+     <p>If <var>fragment directive input</var> does not match the <a data-link-type="dfn" href="#fragmentdirective" id="ref-for-fragmentdirective③">FragmentDirective</a> production, then return an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list④">list</a>.</p>
     <li data-md>
-     <p>Let <em>directives</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a>s
-that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split">strictly splitting the string</a> <em>fragment directive input</em> on "&amp;".</p>
+     <p>Let <em>directives</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a>s
+   that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split">strictly splitting the string</a> <var>fragment directive input</var> on "&amp;".</p>
     <li data-md>
-     <p>Let <em>ranges</em> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list④">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑥">Range</a></code>s that is
-initially empty.</p>
+     <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑥">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑧">Range</a></code>s, initially empty.</p>
     <li data-md>
-     <p>For each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a> <em>directive</em> in <em>directives</em>:</p>
+     <p>For each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> <var>directive</var> of <var>directives</var>:</p>
      <ol>
       <li data-md>
-       <p>If <em>directive</em> does not match the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a>,
-then continue.</p>
+       <p>If <var>directive</var> does not match the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective③">TextDirective</a>,
+   then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</p>
       <li data-md>
-       <p>If the result of <a href="#find-a-matching-range">§ 3.5.4 Find a matching Range</a> on <em>directive</em> is
-non-null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> it to <em>ranges</em>.</p>
-     </ol>
-    <li data-md>
-     <p>Return <em>ranges</em>.</p>
-   </ol>
-   <h4 class="heading settled" data-level="3.5.3" id="parse-a-text-directive"><span class="secno">3.5.3. </span><span class="content">Parse a text directive</span><a class="self-link" href="#parse-a-text-directive"></a></h4>
-   <div class="note" role="note">
-    <p> This algorithm takes a single text directive string as input (e.g.
-    "text=prefix-,foo,bar") and attempts to parse the string into the
-    components of the directive (e.g. "prefix", "foo", "bar"). See <a href="#syntax">§ 3.2 Syntax</a> for the what each of these components means and how they’re used. </p>
-    <p> Returns null if the input is invalid or fails to parse in any way.
-    Otherwise, returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct">struct</a> containing four strings: <em>textStart</em>, <em>textEnd</em>, <em>prefix</em>, <em>suffix</em>.
-    Only <em>textStart</em> is required to be non-null as the other parameters
-    are optional and may be omitted in a valid text directive string. </p>
-   </div>
-   <ol>
-    <li data-md>
-     <p>Let <var>raw target text</var> be the substring of <em>text directive
-   input</em> starting at index 5.</p>
-     <div class="note" role="note"> This is the remainder of the <em>text directive input</em> following,
- but not including, the "text=" prefix. </div>
-    <li data-md>
-     <p>Let <var>tokens</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of strings that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <var>raw target text</var> on commas</a>.</p>
-    <li data-md>
-     <p>If <var>tokens</var> has size less than 1 or greater than 4, return null.</p>
-    <li data-md>
-     <p>If any of <var>tokens</var>’ items are the empty string, return null.</p>
-    <li data-md>
-     <p>Let <var>retVal</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct①">struct</a> consisting of four strings: <em>textStart</em>, <em>textEnd</em>, <em>prefix</em> and <em>suffix</em>, each initialized to null.</p>
-    <li data-md>
-     <p>Let <var>potential prefix</var> be the first item of <var>tokens</var>.</p>
-    <li data-md>
-     <p>If the last character of <em>potential prefix</em> is U+002D (-), then:</p>
-    <li data-md>
-     <p>Set <em>retVal.prefix</em> to the result of removing the last character from <em>potential prefix</em>.</p>
-    <li data-md>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> the first item of the list <var>tokens</var>.</p>
-    <li data-md>
-     <p>Let <em>potential suffix</em> be the last item of <var>tokens</var>, if one exists.</p>
-    <li data-md>
-     <p>If the first character of <em>potential suffix</em> is U+002D (-), then:</p>
-     <ol>
+       <p>Let <var>parsed values</var> be the result of running the <a data-link-type="dfn" href="#parse-a-text-directive" id="ref-for-parse-a-text-directive">parse a text
+   directive</a> steps on <var>directive</var>.</p>
       <li data-md>
-       <p>Set <em>retVal.suffix</em> to the result of removing the first character from <em>potential suffix</em>.</p>
+       <p>If <var>parsed values</var> is null then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove①">Remove</a> the last item of the list <var>tokens</var>.</p>
-     </ol>
-    <li data-md>
-     <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> not equal to 1 nor 2 then
-   return null.</p>
-    <li data-md>
-     <p>Let <em>retVal.textStart</em> be the first item of <var>tokens</var>.</p>
-    <li data-md>
-     <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size①">size</a> 2, then let <em>retVal.textEnd</em> be the last item of <var>tokens</var>.</p>
-    <li data-md>
-     <p>Return <var>retVal</var></p>
-   </ol>
-   <h4 class="heading settled" data-level="3.5.4" id="find-a-matching-range"><span class="secno">3.5.4. </span><span class="content">Find a matching Range</span><a class="self-link" href="#find-a-matching-range"></a></h4>
-   <div class="note" role="note">
-    <p> This algorithm takes a single <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> <var>directive</var> as
-    input (e.g.  "text=prefix-,foo,bar") and returns the first <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑦">Range</a></code> in the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> that corresponds to the match string(s) in the text directive
-    and satisfies the prefix and suffix (if given).  Returns null if no such <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑧">Range</a></code> exists. </p>
-   </div>
-   <p>To find the target text for a given string <var>directive</var>, the user agent must run
-these steps:</p>
-   <ol>
-    <li data-md>
-     <p>If <var>directive</var> does not begin with the string "text=",
-   then return null.</p>
-    <li data-md>
-     <p>Let <var>parsed values</var> be the result of running <a href="#parse-a-text-directive">§ 3.5.3 Parse a text directive</a> on <var>directive</var>.</p>
-    <li data-md>
-     <p>If <var>parsed values</var> is null, return null.</p>
-    <li data-md>
-     <p>Let <var>prefix</var>, <var>textStart</var>, <var>textEnd</var>, and <var>suffix</var> be the values of the
+       <p>Let <var>prefix</var>, <var>textStart</var>, <var>textEnd</var>, and <var>suffix</var> be the values of the
    equivalent items in <var>parsed values</var>.</p>
-    <li data-md>
-     <p>Let <var>walker</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker">TreeWalker</a></code> equal to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createtreewalker" id="ref-for-dom-document-createtreewalker">document.createTreeWalker()</a></code>.</p>
-    <li data-md>
-     <p>Let <var>position</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable①">position variable</a> that indicates a text offset in <em>walker.currentNode.innerText</em>.</p>
-    <li data-md>
-     <p>If <var>textEnd</var> is null, then:</p>
-     <ol>
       <li data-md>
-       <p>Let <var>match position</var> be the result of <a href="#find-match-with-context">§ 3.5.5 Find an exact match with context</a> with input walker <var>walker</var>, search position <var>position</var>,
-prefix <var>prefix</var>, query <var>textStart</var>, and suffix <var>suffix</var>.</p>
-      <li data-md>
-       <p>If <var>match position</var> is null, return null.</p>
-      <li data-md>
-       <p>Let <var>match</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑨">Range</a></code> in <em>walker.currentNode</em> with
-position <var>match position</var> and length equal to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length">length</a> of <var>textStart</var>.</p>
-      <li data-md>
-       <p>Return <var>match</var>.</p>
+       <p>If the result of running <a data-link-type="dfn" href="#find-range-from-a-text-directive" id="ref-for-find-range-from-a-text-directive">find range from a text directive</a> on <var>prefix</var>, <var>textStart</var>, <var>textEnd</var>, <var>suffix</var>, <var>document</var> is non-null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> it to <var>ranges</var>.</p>
      </ol>
     <li data-md>
-     <p>Otherwise, let <var>potential start position</var> be the result of <a href="#find-match-with-context">§ 3.5.5 Find an exact match with context</a> with input walker <var>walker</var>, start position <var>position</var>, prefix <var>prefix</var>, query <var>textStart</var>, and suffix <var>null</var>.</p>
-    <li data-md>
-     <p>If <var>potential start position</var> is null, then return null.</p>
-    <li data-md>
-     <p>Let <var>end position</var> be the result of <a href="#find-match-with-context">§ 3.5.5 Find an exact match with context</a> with input
-   walker <var>walker</var>, search position <var>potential start position</var>, prefix <var>null</var>,
-   query <var>textEnd</var>, and suffix <var>suffix</var>.</p>
-    <li data-md>
-     <p>If <var>end position</var> is null, then return null.</p>
-    <li data-md>
-     <p>Advance <var>end position</var> by the length of <var>textEnd</var>.</p>
-    <li data-md>
-     <p>Let <var>match</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①⓪">Range</a></code> in <em>walker.currentNode</em> with start
-   position <var>potential start position</var> and length equal to <var>end position</var> - <var>start
-   position</var>.</p>
-    <li data-md>
-     <p>Return <var>match</var>.</p>
+     <p>Return <var>ranges</var>.</p>
    </ol>
-   <h4 class="heading settled" data-level="3.5.5" id="find-match-with-context"><span class="secno">3.5.5. </span><span class="content">Find an exact match with context</span><a class="self-link" href="#find-match-with-context"></a></h4>
-   <div class="note" role="note"> This algorithm has input <var>walker</var>, <var>search position</var>, <var>prefix</var>, <var>query</var>, and <var>suffix</var> and returns a text position that is the start of the match. </div>
-   <div class="note" role="note"> The input <var>walker</var> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker①">TreeWalker</a></code> reference, not a copy, i.e. any
-  modifications are performed on the caller’s instance of <var>walker</var>. </div>
+   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-range-from-a-text-directive">find range from a text directive</dfn>, run the following steps:</p>
+   <div class="note" role="note">
+     This algorithm takes as input four strings: <var>prefix</var>, <var>textStart</var>, <var>textEnd</var>,
+  and <var>suffix</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a> <var>document</var> in which to search. It returns a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range⑨">Range</a></code> that points to a the first text passage within the document that
+  matches the searched-for text and satisfies the surrounding context. Returns
+  null if no such passage exists. 
+    <p>See <a href="#syntax">§ 3.2 Syntax</a> for a description of how these parameters are interpreted.</p>
+    <p><var>textEnd</var> is optional. If omitted, this is an "exact" search and the returned <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①⓪">Range</a></code> must contain a string exactly matching <var>textStart</var>. If <var>textEnd</var> is
+  provided, this is a "range" search; the returned <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①①">Range</a></code> must start with <var>textStart</var> and end with <var>textEnd</var>. In the normative text below, we’ll call a
+  text passage that matches the provided <var>textStart</var> and <var>textEnd</var>, regardless
+  of which mode we’re in, the "matching text".</p>
+    <p><var>prefix</var> and <var>suffix</var> are both optional, either or both may be omitted, in
+  which case context on that side of a match is not checked. e.g. If <var>prefix</var> is null, text is matched without any requirement on what text precedes it.</p>
+   </div>
    <ol>
     <li data-md>
-     <p>While <em>walker.currentNode</em> is not null:</p>
+     <p>Let <var>searchRange</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①②">Range</a></code> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start">start</a> (<var>document</var>, 0) and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end">end</a> (<var>document</var>, <var>document</var>’s <a data-link-type="dfn">length</a>)</p>
+    <li data-md>
+     <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed">collapsed</a>:</p>
      <ol>
       <li data-md>
-       <p class="assertion">Assert: <em>walker.currentNode</em> is a text node.</p>
+       <p>Let <var>potentialMatch</var> be null.</p>
       <li data-md>
-       <p>Let <var>text</var> be equal to <em>walker.currentNode.innerText</em>.</p>
-      <li data-md>
-       <p>While <var>search position</var> does not point past the end of <var>text</var>:</p>
+       <p>If <var>prefix</var> is not null:</p>
        <ol>
         <li data-md>
-         <p>If <var>prefix</var> is not null, then:</p>
-         <ol>
-          <li data-md>
-           <p>Advance <var>search position</var> to the position after the result
-of <a href="#next-word-bounded-instance">§ 3.5.7 Find the next word bounded instance</a> of <var>prefix</var> in <var>text</var> from <var>search position</var> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale">current
-locale</a>.</p>
-          <li data-md>
-           <p>If <var>search position</var> is null, then break.</p>
-          <li data-md>
-           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace">Skip ASCII whitespace</a> on <var>search
-position</var>.</p>
-          <li data-md>
-           <p>If <var>search position</var> is at the end of <var>text</var>, then:</p>
-           <ol>
-            <li data-md>
-             <p>Perform <a href="#advance-walker-to-text">§ 3.5.6 Advance a TreeWalker to the next text node</a> on <var>walker</var>.</p>
-            <li data-md>
-             <p>If <em>walker.currentNode</em> is null, then return null.</p>
-            <li data-md>
-             <p>Set <var>text</var> to <em>walker.currentNode.innerText</em>.</p>
-            <li data-md>
-             <p>Set <var>search position</var> to the beginning of <var>text</var>.</p>
-            <li data-md>
-             <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace①">Skip ASCII whitespace</a> on <var>search
-position</var>.</p>
-           </ol>
-          <li data-md>
-           <p>If the result of <a href="#next-word-bounded-instance">§ 3.5.7 Find the next word bounded instance</a> of <var>query</var> in <var>text</var> from <var>search position</var> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale①">current locale</a> does not start at <var>search
-position</var>, then continue.</p>
-         </ol>
+         <p>Let <var>prefixMatch</var> be the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①③">Range</a></code> representing the first instance
+   of <var>prefix</var> in <var>searchRange</var> by running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range">find a string in
+   range</a> steps.</p>
         <li data-md>
-         <p>Advance <var>search position</var> to the position after the result of <a href="#next-word-bounded-instance">§ 3.5.7 Find the next word bounded instance</a> of <var>query</var> in <var>text</var> from <var>search position</var> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale②">current locale</a>.</p>
-         <div class="note" role="note"> If a prefix was specified, the search position is at the
-  beginning of <var>query</var> and this will advance it to the end
-  of the query to search for a potential suffix. Otherwise, this
-  will find the next instance of query. </div>
+         <p>If <var>prefixMatch</var> is null, return null.</p>
         <li data-md>
-         <p>If <var>search position</var> is null, then break.</p>
+         <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①">start</a> to <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①">end</a>.</p>
         <li data-md>
-         <p>Let <var>potential match position</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable②">position variable</a> equal to <var>search
-position</var> minus the length of <var>query</var>.</p>
+         <p>Advance <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start②">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position">next non-whitespace position</a>.</p>
         <li data-md>
-         <p>If <var>suffix</var> is null, then return <var>potential
-match position</var>.</p>
+         <p>If <var>searchRange</var> is <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed①">collapsed</a> return null.</p>
+         <div class="note" role="note"> This can happen if <var>prefix</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end②">end</a> or its subsequent
+ non-whitespace position is at the end of the document. </div>
         <li data-md>
-         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace②">Skip ASCII whitespace</a> on <var>search position</var>.</p>
+         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">assert</a>: <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text">Text</a></code> node.</p>
+         <div class="note" role="note"> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start③">start</a> now points to the next
+ non-whitespace text data following a matched prefix. </div>
         <li data-md>
-         <p>If <var>search position</var> is at the end of <var>text</var>, then:</p>
-         <ol>
-          <li data-md>
-           <p>Let <var>suffix_walker</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker②">TreeWalker</a></code> that is a copy of <var>walker</var>.</p>
-          <li data-md>
-           <p>Perform <a href="#advance-walker-to-text">§ 3.5.6 Advance a TreeWalker to the next text node</a> on <var>suffix_walker</var>.</p>
-          <li data-md>
-           <p>If <em>suffix_walker.currentNode</em> is null, then return null.</p>
-          <li data-md>
-           <p>Set <var>text</var> to <em>suffix_walker.currentNode.innerText</em>.</p>
-          <li data-md>
-           <p>Set <var>search position</var> to the beginning of <var>text</var>.</p>
-          <li data-md>
-           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#skip-ascii-whitespace" id="ref-for-skip-ascii-whitespace③">Skip ASCII whitespace</a> on <var>search
-position</var>.</p>
-         </ol>
+         <p>Set <var>potentialMatch</var> to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①④">Range</a></code> representing the first
+   instance of a matching text in <var>searchRange</var> by following the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range①">find a string in range</a> steps
+   searching for <var>textStart</var>, <var>textEnd</var>.</p>
         <li data-md>
-         <p>If the result of <a href="#next-word-bounded-instance">§ 3.5.7 Find the next word bounded instance</a> of <var>suffix</var> in <var>text</var> from <var>search position</var> with <a data-link-type="dfn" href="#current-locale" id="ref-for-current-locale③">current
-locale</a> starts at <var>search position</var>, then return <var>potential match position</var>.</p>
+         <p>If <var>potentialMatch</var> is null or its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start④">start</a> is not <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑤">start</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">continue</a>.</p>
+         <div class="note" role="note"> In this case, we found a prefix but it was followed by something
+ other than a matching text so we’ll continue searching for the
+ next instance of <var>prefix</var>. </div>
        </ol>
       <li data-md>
-       <p>Perform <a href="#advance-walker-to-text">§ 3.5.6 Advance a TreeWalker to the next text node</a> on <var>walker</var>.</p>
+       <p>Otherwise:</p>
+       <ol>
+        <li data-md>
+         <p>Set <var>potentialMatch</var> to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①⑤">Range</a></code> representing the first
+   instance of a matching text in <var>searchRange</var> by following the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range②">find a string in range</a> steps
+   searching for <var>textStart</var>, <var>textEnd</var>.</p>
+        <li data-md>
+         <p>If <var>potentialMatch</var> is null, return null.</p>
+        <li data-md>
+         <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑥">start</a> to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end③">end</a>.</p>
+       </ol>
+      <li data-md>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">assert</a>: <var>potentialMatch</var> is non-null, not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed②">collapsed</a> and
+   represents a range exactly containing an instance of matching text.</p>
+      <li data-md>
+       <p>If <var>suffix</var> is null, return <var>potentialMatch</var>.</p>
+      <li data-md>
+       <p>Let <var>suffixRange</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①⑥">Range</a></code> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑦">start</a> equal to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end④">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑤">end</a> equal to <var>search
+   range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑥">end</a>.</p>
+      <li data-md>
+       <p>Advance <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑧">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position①">next non-whitespace
+   position</a>.</p>
+      <li data-md>
+       <p>Let <var>suffix match</var> be the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①⑦">Range</a></code> representing the first
+   instance of <var>suffix</var> in <var>suffixRange</var> by following the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range③">find a string in range</a> steps.</p>
+      <li data-md>
+       <p>If <var>suffix match</var> is null then return null</p>
+       <div class="note" role="note"> If the suffix doesn’t appear in the remaining text of the document,
+ there’s no possible way to make a match. </div>
+      <li data-md>
+       <p>If <var>suffix match</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑨">start</a> is <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⓪">start</a>,
+   return <var>potentialMatch</var></p>
+     </ol>
+   </ol>
+   <p>To advance a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①⑧">Range</a></code> <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①①">start</a> to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="next non-whitespace position" data-noexport id="next-non-whitespace-position">next
+non-whitespace position</dfn> follow the steps:</p>
+   <ol>
+    <li data-md>
+     <p>While <var>range</var> is not collapsed:</p>
+     <ol>
+      <li data-md>
+       <p>Let <var>node</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node①">start node</a></p>
+      <li data-md>
+       <p>Let <var>offset</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset">start offset</a></p>
+      <li data-md>
+       <p>If <var>node</var> is part of a <a data-link-type="dfn" href="#non-searchable-subtree" id="ref-for-non-searchable-subtree">non-searchable subtree</a> then:</p>
+       <ol>
+        <li data-md>
+         <p>Set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node②">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order">shadow-including tree order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant">shadow-including
+   descendant</a> of <var>node</var></p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue③">continue</a>.</p>
+       </ol>
+      <li data-md>
+       <p>If <var>node</var> is not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node">visible text node</a>:</p>
+       <ol>
+        <li data-md>
+         <p>Set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node③">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order①">shadow-including tree order</a></p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue④">continue</a>.</p>
+       </ol>
+      <li data-md>
+       <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-substring" id="ref-for-concept-cd-substring">substring data</a> of <var>node</var> at offset <var>offset</var> and length 6 is equal to the string "&amp;nbsp;" then:</p>
+       <ol>
+        <li data-md>
+         <p>Add 6 to <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset①">start offset</a>.</p>
+       </ol>
+      <li data-md>
+       <p>Otherwise, if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-substring" id="ref-for-concept-cd-substring①">substring data</a> of <var>node</var> at offset <var>offset</var> and length 5 is equal to the string "&amp;nbsp" then:</p>
+       <ol>
+        <li data-md>
+         <p>Add 5 to <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset②">start offset</a>.</p>
+       </ol>
+      <li data-md>
+       <p>Otherwise:</p>
+       <ol>
+        <li data-md>
+         <p>Let <var>cp</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point" id="ref-for-code-point">code point</a> at the <var>offset</var> index in <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data" id="ref-for-concept-cd-data">data</a>.</p>
+        <li data-md>
+         <p>If <var>cp</var> does not have the <a href="http://www.unicode.org/reports/tr44/#White_Space">White_Space</a> property set, return.</p>
+         <div class="note" role="note"> For ASCII characters this is the set: U+0020 SPACE, U+0009 TAB,
+ U+000A LF, U+000B VT, U+000C FF, U+000D CR. </div>
+        <li data-md>
+         <p>Add 1 to <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset③">start offset</a>.</p>
+       </ol>
+      <li data-md>
+       <p>If <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset④">start offset</a> is equal to <var>node</var>’s <a data-link-type="dfn">length</a>, set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node④">start node</a> to the next node in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order②">shadow-including tree order</a>.</p>
+     </ol>
+   </ol>
+   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-string-in-range">find a string in range</dfn> for a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> <var>query</var> in a given <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①⑨">Range</a></code> <var>range</var>, run these steps:</p>
+   <div class="note" role="note"> This algorithm takes as input a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑤">string</a> <var>query</var> and a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range②⓪">Range</a></code> <var>range</var>. It will return a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range②①">Range</a></code> that represents the first <a data-link-type="dfn" href="#word-bounded" id="ref-for-word-bounded">word bounded</a> instance within <var>range</var> of the <var>query</var> text. Returns null if
+  none is found. </div>
+   <div class="note" role="note">
+    <p> The basic premise of this algorithm is to walk all searchable text nodes
+    within a block, collecting them into a list. The list is then concatenated
+    into a single string in which we can search, using the node list to
+    determine offsets with a node so we can return a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range②②">Range</a></code>. </p>
+    <p> Collection breaks when we hit a block node, e.g. searching over this tree: </p>
+<pre>      &lt;div>
+        a&lt;em>b&lt;/em>c&lt;div>d&lt;/div>e
+      &lt;/div>
+</pre>
+    <p></p>
+    <p>Will perform a search on "abc", then on "c", then on "e".</p>
+   </div>
+   <ol>
+    <li data-md>
+     <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed③">collapsed</a>:</p>
+     <ol>
+      <li data-md>
+       <p>Let <var>curNode</var> be <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑤">start node</a>.</p>
+      <li data-md>
+       <p>If <var>curNode</var> is part of a <a data-link-type="dfn" href="#non-searchable-subtree" id="ref-for-non-searchable-subtree①">non-searchable subtree</a>:</p>
+       <ol>
+        <li data-md>
+         <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑥">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order③">shadow-including tree order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant①">shadow-including
+   descendant</a> of <var>curNode</var>.</p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue⑤">continue</a>.</p>
+       </ol>
+      <li data-md>
+       <p>If <var>curNode</var> is not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node①">visible text node</a>:</p>
+       <ol>
+        <li data-md>
+         <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑦">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order④">shadow-including tree order</a>.</p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue⑥">continue</a>.</p>
+       </ol>
+      <li data-md>
+       <p>Otherwise:</p>
+       <ol>
+        <li data-md>
+         <p>Let <var>blockAncestor</var> be the <a data-link-type="dfn" href="#nearest-block-ancestor" id="ref-for-nearest-block-ancestor">nearest block ancestor</a> of <var>curNode</var>.</p>
+        <li data-md>
+         <p>Let <var>textNodeList</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑦">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text①">Text</a></code> nodes,
+   initially empty.</p>
+        <li data-md>
+         <p>While <var>curNode</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant②">shadow-including descendant</a> of <var>blockAncestor</var> and it does not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-following" id="ref-for-concept-tree-following">follow</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node">end node</a>:</p>
+         <ol>
+          <li data-md>
+           <p>If <var>curNode</var> <a data-link-type="dfn" href="#has-block-level-display" id="ref-for-has-block-level-display">has block-level display</a> then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break">break</a>.</p>
+          <li data-md>
+           <p>If <var>curNode</var> is <a data-link-type="dfn" href="#search-invisible" id="ref-for-search-invisible">search invisible</a>:</p>
+           <ol>
+            <li data-md>
+             <p>Set <var>curNode</var> to the next node in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order⑤">shadow-including tree
+   order</a> whose ancestor is not <var>curNode</var></p>
+            <li data-md>
+             <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue⑦">continue</a>.</p>
+           </ol>
+          <li data-md>
+           <p>If <var>curNode</var> is a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node②">visible text node</a> then append it to <var>textNodeList</var>.</p>
+          <li data-md>
+           <p>Set <var>curNode</var> to the next node in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order⑥">shadow-including tree
+   order</a>.</p>
+         </ol>
+        <li data-md>
+         <p>Run the <a data-link-type="dfn" href="#find-a-range-from-a-node-list" id="ref-for-find-a-range-from-a-node-list">find a range from a node list</a> steps given <var>query</var>, <var>searchRange</var>, and <var>textNodeList</var>, as input. If the resulting <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range②③">Range</a></code> is not null, then return it.</p>
+        <li data-md>
+         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert③">assert</a>: <var>curNode</var> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-following" id="ref-for-concept-tree-following①">follows</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑧">start node</a>.</p>
+        <li data-md>
+         <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①②">start</a> to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp">boundary point</a> (<var>curNode</var>, 0).</p>
+       </ol>
+     </ol>
+    <li data-md>
+     <p>Return null</p>
+   </ol>
+   <p>A node is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="search-invisible">search invisible</dfn> if it is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement" id="ref-for-htmlelement">HTMLElement</a></code> and meets any
+of the following conditions:</p>
+   <ol>
+    <li data-md>
+     <p>The <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#computed-value" id="ref-for-computed-value">computed value</a> of its <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display">display</a> property is <a class="property" data-link-type="propdesc">none</a></p>
+    <li data-md>
+     <p>It has a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-local-name" id="ref-for-concept-element-local-name">local name</a> equal to any of the following: "area",
+   "base", "basefont", "bgsound", "br", "col", "embed", "frame", "hr", "img",
+   "keygen", "link", "menuitem", "meta", "param", "source", "track", "wbr"</p>
+    <li data-md>
+     <p>Is any of the following types: <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement" id="ref-for-htmliframeelement">HTMLIFrameElement</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement" id="ref-for-htmlimageelement">HTMLImageElement</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement" id="ref-for-htmlmeterelement">HTMLMeterElement</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement" id="ref-for-htmlobjectelement">HTMLObjectElement</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement" id="ref-for-htmlprogresselement">HTMLProgressElement</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement" id="ref-for-htmlstyleelement">HTMLStyleElement</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement" id="ref-for-htmlscriptelement">HTMLScriptElement</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement" id="ref-for-htmlvideoelement">HTMLVideoElement</a></code>, <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement" id="ref-for-htmlaudioelement">HTMLAudioElement</a></code></p>
+    <li data-md>
+     <p>Is an <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlselectelement" id="ref-for-htmlselectelement">HTMLSelectElement</a></code> whose <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-multiple" id="ref-for-dom-select-multiple">multiple</a></code> attribute
+   is false.</p>
+   </ol>
+   <p>A node is part of a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="non-searchable-subtree">non-searchable subtree</dfn> if it is or has an
+ancestor that is <a data-link-type="dfn" href="#search-invisible" id="ref-for-search-invisible①">search invisible</a>.</p>
+   <p>A node is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="visible-text-node">visible text node</dfn> if it is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text②">Text</a></code> node, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#computed-value" id="ref-for-computed-value①">computed value</a> of its <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> property is <a class="property" data-link-type="propdesc">visible</a>, and it is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered" id="ref-for-being-rendered">being rendered</a>.</p>
+   <p>A node <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="has-block-level-display">has block-level display</dfn> if the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#computed-value" id="ref-for-computed-value②">computed value</a> of its <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display①">display</a> property is any of <a class="property" data-link-type="propdesc">block</a>, <a class="property" data-link-type="propdesc">table</a>, <a class="property" data-link-type="propdesc">flow-root</a>, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-grid-1/#propdef-grid" id="ref-for-propdef-grid">grid</a>, <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex" id="ref-for-propdef-flex">flex</a>, <a class="property" data-link-type="propdesc">list-item</a>.</p>
+   <p>To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="nearest-block-ancestor">nearest block ancestor</dfn> of a <var>node</var> follow the steps:</p>
+   <ol>
+    <li data-md>
+     <p>While <var>node</var> is non-null</p>
+     <ol>
+      <li data-md>
+       <p>If <var>node</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text③">Text</a></code> node and it <a data-link-type="dfn" href="#has-block-level-display" id="ref-for-has-block-level-display①">has block-level display</a> then
+   return <var>node</var>.</p>
+      <li data-md>
+       <p>Otherwise, set <var>node</var> to <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent">parent</a>.</p>
+     </ol>
+    <li data-md>
+     <p>Return <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#document-element" id="ref-for-document-element">document element</a></p>
+   </ol>
+   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-node-list">find a range from a node list</dfn> given a search string <var>queryString</var>, a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range②④">Range</a></code> <var>searchRange</var>, and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑧">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#node" id="ref-for-node">Node</a></code>s <var>nodes</var>,
+follow the steps</p>
+   <div class="note" role="note">
+     This will only return a match if the matched text falls on word boundaries.
+  That is, the text match must begin and end on a word boundary. For example: 
+    <div class="example" id="example-aff7ef7a"><a class="self-link" href="#example-aff7ef7a"></a> “range” will match in “mountain range” but not in “color orange” nor
+    “forest ranger”. </div>
+    <p>See <a href="#word-boundaries">§ 3.5.3 Word Boundaries</a> for details and more examples.</p>
+   </div>
+   <ol>
+    <li data-md>
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert④">assert</a>: each item in <var>nodes</var> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text④">Text</a></code> node.</p>
+    <li data-md>
+     <p>Let <var>searchBuffer</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-concatenate" id="ref-for-string-concatenate">concatenation</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data" id="ref-for-concept-cd-data①">data</a> field of each item in in <var>nodes</var>.</p>
+    <li data-md>
+     <p>Let <var>searchStart</var> be 0</p>
+    <li data-md>
+     <p>If the first item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑨">start node</a> then
+   set <var>searchStart</var> to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑤">start offset</a>.</p>
+    <li data-md>
+     <p>Let <var>start</var>, <var>end</var> be <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp①">boundary point</a>s, initially null.</p>
+    <li data-md>
+     <p>Let <var>matchIx</var> be null.</p>
+    <li data-md>
+     <p>While <var>matchIx</var> is null</p>
+     <ol>
+      <li data-md>
+       <p>Let <var>matchIx</var> be the first <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable①">position variable</a> in <var>searchBuffer</var>, greater
+   than or equal to <var>searchStart</var>, where <var>queryString</var> occurs. That is, for each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable②">position variable</a> <var>j</var> in <var>searchRange</var>, the <var>j</var>th code point in <var>queryString</var> is equal to the (<var>matchIx</var>+<var>j</var>)th code point in <var>searchBuffer</var>. If no
+   such <var>matchIx</var> exists, return null.</p>
+       <div class="note" role="note"> In plain language: find the index of the first instance of <var>queryString</var> in <var>searchBuffer</var>, starting at <var>searchStart</var>. </div>
+      <li data-md>
+       <p>Let <var>endIx</var> be <var>matchIx</var> + <var>queryString</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length">length</a>.</p>
+       <div class="note" role="note"> <var>endIx</var> is the index of the last character in the match + 1. </div>
+      <li data-md>
+       <p>Set <var>start</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp②">boundary point</a> result of <a data-link-type="dfn" href="#get-boundary-point-at-index" id="ref-for-get-boundary-point-at-index">get boundary point at
+   index</a> <var>matchIx</var> run over <var>nodes</var> with <var>isEnd</var> false.</p>
+      <li data-md>
+       <p>Set <var>end</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp③">boundary point</a> result of <a data-link-type="dfn" href="#get-boundary-point-at-index" id="ref-for-get-boundary-point-at-index①">get boundary point at
+   index</a> <var>endIx</var> run over <var>nodes</var> with <var>isEnd</var> true.</p>
+      <li data-md>
+       <p>If the substring of <var>searchBuffer</var> starting at <var>matchIx</var> and of length <var>queryString</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length①">length</a> is not <a data-link-type="dfn" href="#word-bounded" id="ref-for-word-bounded①">word bounded</a>, given the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#language" id="ref-for-language">language</a> from each of <var>start</var> and <var>end</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#boundary-point-node" id="ref-for-boundary-point-node">node</a>s as the <var>startLocale</var> and <var>endLocale</var>:</p>
+       <ol>
+        <li data-md>
+         <p>Let <var>searchStart</var> be <var>matchIx</var> + 1.</p>
+        <li data-md>
+         <p>Set <var>matchIx</var> to null.</p>
+       </ol>
+     </ol>
+    <li data-md>
+     <p>Let <var>endInset</var> be 0.</p>
+    <li data-md>
+     <p>If the last item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node①">end node</a> then set <var>endInset</var> to (<var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node②">end node</a>'s <a data-link-type="dfn">length</a> - <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-offset" id="ref-for-concept-range-end-offset">end offset</a>)</p>
+     <div class="note" role="note"> <var>endInset</var> is the offset from the last position in the last node in the
+ reverse direction. Alternatively, it is the length of the node that’s not
+ included in the range. </div>
+    <li data-md>
+     <p>If <var>matchIx</var> + <var>queryString</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length②">length</a> is greater than or equal to <var>searchBuffer</var>’s length - <var>endInset</var> return null.</p>
+     <div class="note" role="note"> If the match runs past the end of the search range, return null. </div>
+    <li data-md>
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert⑤">assert</a>: <var>start</var> and <var>end</var> are non-null, valid <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp④">boundary point</a>s in <var>searchRange</var>.</p>
+    <li data-md>
+     <p>Return a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range②⑤">Range</a></code> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①③">start</a> <var>start</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑦">end</a> <var>end</var>.</p>
+   </ol>
+   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="get-boundary-point-at-index">get boundary point at index</dfn>, given a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable③">position variable</a> <var>index</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑨">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text⑤">Text</a></code> nodes <var>nodes</var>, and a boolean <var>isEnd</var>, follow
+these steps:</p>
+   <div class="note" role="note">
+    <p> This is a small helper routine used by the steps above to determine which
+    node a given index in the concatenated string belongs to. </p>
+    <p> <var>isEnd</var> is used to differentiate start and end indices. An end index points
+    to the "one-past-last" character of the matching string. If the match ends
+    at node boundary, we want the end offset to remain within that node, rather
+    than the start of the next node. </p>
+   </div>
+   <ol>
+    <li data-md>
+     <p>Let <var>counted</var> be 0.</p>
+    <li data-md>
+     <p>For each <var>curNode</var> of <var>nodes</var>:</p>
+     <ol>
+      <li data-md>
+       <p>Let <var>nodeEnd</var> be <var>counted</var> + <var>curNode</var>’s <a data-link-type="dfn">length</a>.</p>
+      <li data-md>
+       <p>If <var>isEnd</var> is true, add 1 to <var>nodeEnd</var>.</p>
+      <li data-md>
+       <p>If <var>nodeEnd</var> is greater than <var>index</var> then:</p>
+       <ol>
+        <li data-md>
+         <p>Return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑤">boundary point</a> (<var>curNode</var>, <var>index</var> - <var>counted</var>).</p>
+       </ol>
+      <li data-md>
+       <p>Increment <var>counted</var> by <var>curNode</var>’s <a data-link-type="dfn">length</a>.</p>
      </ol>
     <li data-md>
      <p>Return null.</p>
    </ol>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="current-locale">current locale</dfn> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#language" id="ref-for-language">language</a> of the <var>currentNode</var>.</p>
-   <h4 class="heading settled" data-level="3.5.6" id="advance-walker-to-text"><span class="secno">3.5.6. </span><span class="content">Advance a TreeWalker to the next text node</span><a class="self-link" href="#advance-walker-to-text"></a></h4>
-   <div class="note" role="note"> The input <em>walker</em> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#treewalker" id="ref-for-treewalker③">TreeWalker</a></code> reference, not a
-  copy, i.e. any modifications are performed on the caller’s instance of <em>walker</em>. </div>
-   <ol>
-    <li data-md>
-     <p>While the input <em>walker.currentNode</em> is not null and <em>walker.currentNode</em> is not a text node:</p>
-     <ol>
-      <li data-md>
-       <p>Advance the current node by calling <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode" id="ref-for-dom-treewalker-nextnode">walker.nextNode()</a></code>.</p>
-     </ol>
-   </ol>
-   <h4 class="heading settled" data-level="3.5.7" id="next-word-bounded-instance"><span class="secno">3.5.7. </span><span class="content">Find the next word bounded instance</span><a class="self-link" href="#next-word-bounded-instance"></a></h4>
-   <div class="note" role="note"> This algorithm has input <var>query</var>, <var>text</var>, <var>start position</var>, and <var>locale</var> and
-returns a Range that specifies the word bounded text instance if it is found. </div>
+   <h4 class="heading settled" data-level="3.5.3" id="word-boundaries"><span class="secno">3.5.3. </span><span class="content">Word Boundaries</span><a class="self-link" href="#word-boundaries"></a></h4>
    <div class="note" role="note"> Limiting matching to word boundaries is one of the mitigations to limit
-cross-origin information leakage. </div>
-   <div class="note" role="note"> See <a href="https://github.com/tc39/proposal-intl-segmenter">Intl.Segmenter</a>,
-a proposal to specify unicode segmentation, including word segmentation. Once
-specified, this algorithm may be improved by making use of the Intl.Segmenter
-API for word boundary matching. </div>
+  cross-origin information leakage. </div>
+   <div class="note" role="note"> See <a href="https://github.com/tc39/proposal-intl-segmenter">Intl.Segmenter</a>, a
+  proposal to specify unicode segmentation, including word segmentation. Once
+  specified, this algorithm may be improved by making use of the Intl.Segmenter
+  API for word boundary matching. </div>
    <p> A word boundary is as defined in the <a href="http://www.unicode.org/reports/tr29/#Word_Boundaries">Unicode
   text segmentation annex</a>. The <a href="http://www.unicode.org/reports/tr29/#Default_Word_Boundaries"> Default Word Boundary Specification</a> defines a default set of
   what constitutes a word boundary, but as the specification mentions,
@@ -2249,25 +2490,48 @@ API for word boundary matching. </div>
   those cases, and where the alphabet contains fewer than 100
   characters, the dictionary must not contain more than 20% of the
   alphabet as valid, one-letter words. </p>
+   <p>To determine if a substring of a larger string is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-bounded">word bounded</dfn>,
+follow these steps:</p>
+   <div class="note" role="note">
+     This algorithm takes as input a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑥">string</a> <var>text</var>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable④">position variable</a> <var>start position</var> and number <var>count</var>; representing
+  a substring in <var>text</var>, as well as a <var>startLocale</var> and <var>endLocale</var> specifying
+  the language of the string at each end of the match. 
+    <p><var>start position</var> and <var>count</var> are assumed to be valid in that they represent a
+  substring within the bounds of <var>text</var>.</p>
+    <p>Returns true if the substring is word bounded, false otherwise.</p>
+   </div>
+   <div class="note" role="note">
+     Intuitively, a substring is word bounded if it neither begins nor ends in the
+  middle of a word. 
+    <p>In languages with a word separator (e.g. " " space) this is (mostly)
+  straightforward; though there are details covered by the above technical
+  reports such as new lines, hyphenations, quotes, etc.</p>
+    <p>Some languages do not have such a separator (notably,
+  Chinese/Japanese/Korean). Languages such as these requires dictionaries to
+  determine what a valid word in the given locale is.</p>
+   </div>
    <ol>
     <li data-md>
-     <p>While <var>start position</var> does not point past the end of <var>text</var>:</p>
-     <ol>
-      <li data-md>
-       <p>Advance <var>start position</var> to the next instance of <var>query</var> in <var>text</var>.</p>
-      <li data-md>
-       <p>Let <var>range</var> be a Range with position <var>start position</var> and length equal to
-the length of <var>query</var>.</p>
-      <li data-md>
-       <p>Using locale <var>locale</var>, let <var>left bound</var> be the last word boundary in <var>text</var> before <var>range</var>.</p>
-      <li data-md>
-       <p>Using locale <var>locale</var>, let <var>right bound</var> be the first word boundary in <var>text</var> after <var>range</var>.</p>
-      <li data-md>
-       <p>If <var>left bound</var> immediately precedes <var>range</var> and <var>right bound</var> immediately follows <var>range</var>, then return <var>range</var>.</p>
-     </ol>
+     <p>Using locale <var>startLocale</var>, let <var>left bound</var> be the last word boundary in <var>text</var> that precedes <var>start position</var>th <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point" id="ref-for-code-point①">code point</a> of <var>text</var>.</p>
+     <div class="note" role="note"> A string will always contain at least 2 word boundaries before the first
+ code point and after the last code point of the string. </div>
     <li data-md>
-     <p>Return null.</p>
+     <p>If the first <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point" id="ref-for-code-point②">code point</a> of <var>text</var> following <var>left bound</var> is not at
+   position <var>start position</var> return false.</p>
+    <li data-md>
+     <p>Let <var>end position</var> be (<var>start position</var> + <var>count</var> - 1).</p>
+    <li data-md>
+     <p>Using locale <var>endLocale</var>, let <var>right bound</var> be the first word boundary in <var>text</var> after the <var>end position</var>th <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point" id="ref-for-code-point③">code point</a>.</p>
+    <li data-md>
+     <p>If the first <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point" id="ref-for-code-point④">code point</a> of <var>text</var> preceding <var>right bound</var> is not at
+   position <var>end position</var> return false.</p>
+    <li data-md>
+     <p>Return true.</p>
    </ol>
+   <div class="example" id="example-1b2a6f00"><a class="self-link" href="#example-1b2a6f00"></a> The substring "mountain range" is word bounded within the string "An impressive
+  mountain range" but not within "An impressive mountain ranger". </div>
+   <div class="example" id="example-c7882c95"><a class="self-link" href="#example-c7882c95"></a> In the Japanese string "ウィキペディアへようこそ" (Welcome to Wikipedia),
+  "ようこそ" (Welcome) is considered word-bounded but "ようこ" is not. </div>
    <h3 class="heading settled" data-level="3.6" id="indicating-the-text-match"><span class="secno">3.6. </span><span class="content">Indicating The Text Match</span><a class="self-link" href="#indicating-the-text-match"></a></h3>
    <p>The UA may choose to scroll the text fragment into view as part of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment①">try to scroll to the fragment</a> steps or by some other mechanism;
 however, it is not required to scroll the match into view.</p>
@@ -2324,7 +2588,7 @@ Physical Phenomena" by C. E. Wynn-Williams.
   surface, the text that was being searched for but not found.</p>
    </div>
    <p>Range-based matches can be helpful when the quoted text is excessively long
-and encoding the entire string would produce an unwieldly URL.</p>
+and encoding the entire string would produce an unwieldy URL.</p>
    <p>It is recommended that text snippets shorter than 300 characters always be
 encoded using an exact match. Above this limit, the UA should encode the string
 as a range-based match.</p>
@@ -2547,10 +2811,12 @@ match based on whether the element-id was scrolled.</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#characterstring">CharacterString</a><span>, in §3.3.2</span>
-   <li><a href="#current-locale">current locale</a><span>, in §3.5.5</span>
    <li><a href="#explicitchar">ExplicitChar</a><span>, in §3.3.2</span>
-   <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §3.7</span>
+   <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in §3.5.2</span>
+   <li><a href="#find-a-string-in-range">find a string in range</a><span>, in §3.5.2</span>
+   <li><a href="#find-range-from-a-text-directive">find range from a text directive</a><span>, in §3.5.2</span>
    <li><a href="#fragment-directive">fragment directive</a><span>, in §3.3.1</span>
+   <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §3.7</span>
    <li>
     FragmentDirective
     <ul>
@@ -2558,10 +2824,18 @@ match based on whether the element-id was scrolled.</p>
      <li><a href="#fragmentdirective">definition of</a><span>, in §3.3.2</span>
     </ul>
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §3.3.1</span>
+   <li><a href="#get-boundary-point-at-index">get boundary point at index</a><span>, in §3.5.2</span>
+   <li><a href="#has-block-level-display">has block-level display</a><span>, in §3.5.2</span>
    <li><a href="#location">Location</a><span>, in §3.7</span>
+   <li><a href="#nearest-block-ancestor">nearest block ancestor</a><span>, in §3.5.2</span>
+   <li><a href="#next-non-whitespace-position">next non-whitespace position</a><span>, in §3.5.2</span>
+   <li><a href="#non-searchable-subtree">non-searchable subtree</a><span>, in §3.5.2</span>
+   <li><a href="#parse-a-text-directive">parse a text directive</a><span>, in §3.3.1</span>
    <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §3.3.2</span>
+   <li><a href="#process-a-fragment-directive">process a fragment directive</a><span>, in §3.5.2</span>
    <li><a href="#scroll-a-domrect-into-view">scroll a DOMRect into view</a><span>, in §3.5.1</span>
    <li><a href="#scroll-a-range-into-view">scroll a Range into view</a><span>, in §3.5.1</span>
+   <li><a href="#search-invisible">search invisible</a><span>, in §3.5.2</span>
    <li><a href="#textdirective">TextDirective</a><span>, in §3.3.2</span>
    <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §3.3.2</span>
    <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §3.3.2</span>
@@ -2569,7 +2843,39 @@ match based on whether the element-id was scrolled.</p>
    <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §3.3.2</span>
    <li><a href="#unknowndirective">UnknownDirective</a><span>, in §3.3.2</span>
    <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §3.3.2</span>
+   <li><a href="#visible-text-node">visible text node</a><span>, in §3.5.2</span>
+   <li><a href="#word-bounded">word bounded</a><span>, in §3.5.3</span>
   </ul>
+  <aside class="dfn-panel" data-for="term-for-computed-value">
+   <a href="https://drafts.csswg.org/css-cascade-4/#computed-value">https://drafts.csswg.org/css-cascade-4/#computed-value</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-computed-value">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-propdef-display">
+   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-propdef-display">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-propdef-display①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-propdef-flex">
+   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-propdef-flex">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-propdef-grid">
+   <a href="https://drafts.csswg.org/css-grid-1/#propdef-grid">https://drafts.csswg.org/css-grid-1/#propdef-grid</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-propdef-grid">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
+   <a href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility">https://drafts.csswg.org/css2/visufx.html#propdef-visibility</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-propdef-visibility">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-dictdef-scrollintoviewoptions">
    <a href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions">https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions</a><b>Referenced in:</b>
    <ul>
@@ -2593,7 +2899,6 @@ match based on whether the element-id was scrolled.</p>
    <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3.4.4. Should Allow Text Fragment</a>
-    <li><a href="#ref-for-document①">3.5.4. Find a matching Range</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-node-element_node">
@@ -2609,21 +2914,36 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-element①">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-element②">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-node">
+   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-node">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-range">
    <a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-range①">(2)</a> <a href="#ref-for-range②">(3)</a> <a href="#ref-for-range③">(4)</a>
     <li><a href="#ref-for-range④">3.5.1. Scroll a DOMRect into view</a>
-    <li><a href="#ref-for-range⑤">3.5.2. Find text matches</a> <a href="#ref-for-range⑥">(2)</a>
-    <li><a href="#ref-for-range⑦">3.5.4. Find a matching Range</a> <a href="#ref-for-range⑧">(2)</a> <a href="#ref-for-range⑨">(3)</a> <a href="#ref-for-range①⓪">(4)</a>
+    <li><a href="#ref-for-range⑤">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-range⑥">(2)</a> <a href="#ref-for-range⑦">(3)</a> <a href="#ref-for-range⑧">(4)</a> <a href="#ref-for-range⑨">(5)</a> <a href="#ref-for-range①⓪">(6)</a> <a href="#ref-for-range①①">(7)</a> <a href="#ref-for-range①②">(8)</a> <a href="#ref-for-range①③">(9)</a> <a href="#ref-for-range①④">(10)</a> <a href="#ref-for-range①⑤">(11)</a> <a href="#ref-for-range①⑥">(12)</a> <a href="#ref-for-range①⑦">(13)</a> <a href="#ref-for-range①⑧">(14)</a> <a href="#ref-for-range①⑨">(15)</a> <a href="#ref-for-range②⓪">(16)</a> <a href="#ref-for-range②①">(17)</a> <a href="#ref-for-range②②">(18)</a> <a href="#ref-for-range②③">(19)</a> <a href="#ref-for-range②④">(20)</a> <a href="#ref-for-range②⑤">(21)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-treewalker">
-   <a href="https://dom.spec.whatwg.org/#treewalker">https://dom.spec.whatwg.org/#treewalker</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-text">
+   <a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-treewalker">3.5.4. Find a matching Range</a>
-    <li><a href="#ref-for-treewalker①">3.5.5. Find an exact match with context</a> <a href="#ref-for-treewalker②">(2)</a>
-    <li><a href="#ref-for-treewalker③">3.5.6. Advance a TreeWalker to the next text node</a>
+    <li><a href="#ref-for-text">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-text①">(2)</a> <a href="#ref-for-text②">(3)</a> <a href="#ref-for-text③">(4)</a> <a href="#ref-for-text④">(5)</a> <a href="#ref-for-text⑤">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-range-bp">
+   <a href="https://dom.spec.whatwg.org/#concept-range-bp">https://dom.spec.whatwg.org/#concept-range-bp</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-range-bp">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-bp①">(2)</a> <a href="#ref-for-concept-range-bp②">(3)</a> <a href="#ref-for-concept-range-bp③">(4)</a> <a href="#ref-for-concept-range-bp④">(5)</a> <a href="#ref-for-concept-range-bp⑤">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-range-collapsed">
+   <a href="https://dom.spec.whatwg.org/#range-collapsed">https://dom.spec.whatwg.org/#range-collapsed</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-range-collapsed">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-range-collapsed①">(2)</a> <a href="#ref-for-range-collapsed②">(3)</a> <a href="#ref-for-range-collapsed③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-range-commonancestorcontainer">
@@ -2632,22 +2952,65 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-dom-range-commonancestorcontainer">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-createtreewalker">
-   <a href="https://dom.spec.whatwg.org/#dom-document-createtreewalker">https://dom.spec.whatwg.org/#dom-document-createtreewalker</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-concept-cd-data">
+   <a href="https://dom.spec.whatwg.org/#concept-cd-data">https://dom.spec.whatwg.org/#concept-cd-data</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-document-createtreewalker">3.5.4. Find a matching Range</a>
+    <li><a href="#ref-for-concept-cd-data">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-data①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-document">
    <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-concept-document①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-document②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-treewalker-nextnode">
-   <a href="https://dom.spec.whatwg.org/#dom-treewalker-nextnode">https://dom.spec.whatwg.org/#dom-treewalker-nextnode</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-document-element">
+   <a href="https://dom.spec.whatwg.org/#document-element">https://dom.spec.whatwg.org/#document-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-treewalker-nextnode">3.5.6. Advance a TreeWalker to the next text node</a>
+    <li><a href="#ref-for-document-element">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-range-end">
+   <a href="https://dom.spec.whatwg.org/#concept-range-end">https://dom.spec.whatwg.org/#concept-range-end</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-range-end">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end①">(2)</a> <a href="#ref-for-concept-range-end②">(3)</a> <a href="#ref-for-concept-range-end③">(4)</a> <a href="#ref-for-concept-range-end④">(5)</a> <a href="#ref-for-concept-range-end⑤">(6)</a> <a href="#ref-for-concept-range-end⑥">(7)</a> <a href="#ref-for-concept-range-end⑦">(8)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-range-end-node">
+   <a href="https://dom.spec.whatwg.org/#concept-range-end-node">https://dom.spec.whatwg.org/#concept-range-end-node</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-range-end-node">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end-node①">(2)</a> <a href="#ref-for-concept-range-end-node②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-range-end-offset">
+   <a href="https://dom.spec.whatwg.org/#concept-range-end-offset">https://dom.spec.whatwg.org/#concept-range-end-offset</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-range-end-offset">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-tree-following">
+   <a href="https://dom.spec.whatwg.org/#concept-tree-following">https://dom.spec.whatwg.org/#concept-tree-following</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-tree-following">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-tree-following①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-element-local-name">
+   <a href="https://dom.spec.whatwg.org/#concept-element-local-name">https://dom.spec.whatwg.org/#concept-element-local-name</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-element-local-name">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-boundary-point-node">
+   <a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-boundary-point-node">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-node-document">
+   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-node-document">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-node-nodetype">
@@ -2656,10 +3019,52 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-dom-node-nodetype">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-tree-parent">
+   <a href="https://dom.spec.whatwg.org/#concept-tree-parent">https://dom.spec.whatwg.org/#concept-tree-parent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-tree-parent">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-dom-node-parentnode">
    <a href="https://dom.spec.whatwg.org/#dom-node-parentnode">https://dom.spec.whatwg.org/#dom-node-parentnode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-parentnode">3.5. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-descendant">
+   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-descendant</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-shadow-including-descendant">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-shadow-including-descendant①">(2)</a> <a href="#ref-for-concept-shadow-including-descendant②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order">
+   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-shadow-including-tree-order">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-shadow-including-tree-order①">(2)</a> <a href="#ref-for-concept-shadow-including-tree-order②">(3)</a> <a href="#ref-for-concept-shadow-including-tree-order③">(4)</a> <a href="#ref-for-concept-shadow-including-tree-order④">(5)</a> <a href="#ref-for-concept-shadow-including-tree-order⑤">(6)</a> <a href="#ref-for-concept-shadow-including-tree-order⑥">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-range-start">
+   <a href="https://dom.spec.whatwg.org/#concept-range-start">https://dom.spec.whatwg.org/#concept-range-start</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-range-start">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start①">(2)</a> <a href="#ref-for-concept-range-start②">(3)</a> <a href="#ref-for-concept-range-start③">(4)</a> <a href="#ref-for-concept-range-start④">(5)</a> <a href="#ref-for-concept-range-start⑤">(6)</a> <a href="#ref-for-concept-range-start⑥">(7)</a> <a href="#ref-for-concept-range-start⑦">(8)</a> <a href="#ref-for-concept-range-start⑧">(9)</a> <a href="#ref-for-concept-range-start⑨">(10)</a> <a href="#ref-for-concept-range-start①⓪">(11)</a> <a href="#ref-for-concept-range-start①①">(12)</a> <a href="#ref-for-concept-range-start①②">(13)</a> <a href="#ref-for-concept-range-start①③">(14)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-range-start-node">
+   <a href="https://dom.spec.whatwg.org/#concept-range-start-node">https://dom.spec.whatwg.org/#concept-range-start-node</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-range-start-node">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start-node①">(2)</a> <a href="#ref-for-concept-range-start-node②">(3)</a> <a href="#ref-for-concept-range-start-node③">(4)</a> <a href="#ref-for-concept-range-start-node④">(5)</a> <a href="#ref-for-concept-range-start-node⑤">(6)</a> <a href="#ref-for-concept-range-start-node⑥">(7)</a> <a href="#ref-for-concept-range-start-node⑦">(8)</a> <a href="#ref-for-concept-range-start-node⑧">(9)</a> <a href="#ref-for-concept-range-start-node⑨">(10)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-range-start-offset">
+   <a href="https://dom.spec.whatwg.org/#concept-range-start-offset">https://dom.spec.whatwg.org/#concept-range-start-offset</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-range-start-offset">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start-offset①">(2)</a> <a href="#ref-for-concept-range-start-offset②">(3)</a> <a href="#ref-for-concept-range-start-offset③">(4)</a> <a href="#ref-for-concept-range-start-offset④">(5)</a> <a href="#ref-for-concept-range-start-offset⑤">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-cd-substring">
+   <a href="https://dom.spec.whatwg.org/#concept-cd-substring">https://dom.spec.whatwg.org/#concept-cd-substring</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-cd-substring">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-substring①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-document-url">
@@ -2686,6 +3091,78 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-domrect">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-domrect①">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlaudioelement">
+   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement">https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlaudioelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlelement">
+   <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmliframeelement">
+   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmliframeelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlimageelement">
+   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlimageelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlmeterelement">
+   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlmeterelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlobjectelement">
+   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlobjectelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlprogresselement">
+   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlprogresselement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlscriptelement">
+   <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlscriptelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlselectelement">
+   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlselectelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlselectelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlselectelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlstyleelement">
+   <a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlstyleelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
+   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlvideoelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-being-rendered">
+   <a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-being-rendered">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-browsing-context">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
@@ -2701,13 +3178,19 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-language">
    <a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-language">3.5.5. Find an exact match with context</a>
+    <li><a href="#ref-for-language">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-latest-entry">
    <a href="https://html.spec.whatwg.org/multipage/history.html#latest-entry">https://html.spec.whatwg.org/multipage/history.html#latest-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-entry">3.4.4. Should Allow Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-select-multiple">
+   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-multiple">https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-multiple</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-select-multiple">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-scroll-to-the-fragment-identifier">
@@ -2739,72 +3222,99 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-list-append">
    <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-append">3.5.2. Find text matches</a>
+    <li><a href="#ref-for-list-append">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-assert">
+   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-assert">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-assert①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-assert②">(2)</a> <a href="#ref-for-assert③">(3)</a> <a href="#ref-for-assert④">(4)</a> <a href="#ref-for-assert⑤">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-iteration-break">
+   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-iteration-break">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-code-point">
+   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-code-point">3.5.2. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-code-point①">3.5.3. Word Boundaries</a> <a href="#ref-for-code-point②">(2)</a> <a href="#ref-for-code-point③">(3)</a> <a href="#ref-for-code-point④">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-string-concatenate">
+   <a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-string-concatenate">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-iteration-continue">
+   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-iteration-continue">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a> <a href="#ref-for-iteration-continue③">(4)</a> <a href="#ref-for-iteration-continue④">(5)</a> <a href="#ref-for-iteration-continue⑤">(6)</a> <a href="#ref-for-iteration-continue⑥">(7)</a> <a href="#ref-for-iteration-continue⑦">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-string-length">
    <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string-length">3.5.4. Find a matching Range</a>
+    <li><a href="#ref-for-string-length">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-string-length①">(2)</a> <a href="#ref-for-string-length②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list">
    <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-list①">3.5.2. Find text matches</a> <a href="#ref-for-list②">(2)</a> <a href="#ref-for-list③">(3)</a> <a href="#ref-for-list④">(4)</a>
-    <li><a href="#ref-for-list⑤">3.5.3. Parse a text directive</a>
+    <li><a href="#ref-for-list">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-list①">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-list②">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-list③">(2)</a> <a href="#ref-for-list④">(3)</a> <a href="#ref-for-list⑤">(4)</a> <a href="#ref-for-list⑥">(5)</a> <a href="#ref-for-list⑦">(6)</a> <a href="#ref-for-list⑧">(7)</a> <a href="#ref-for-list⑨">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-string-position-variable">
    <a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-position-variable">3.3.1. Parsing the fragment directive</a>
-    <li><a href="#ref-for-string-position-variable①">3.5.4. Find a matching Range</a>
-    <li><a href="#ref-for-string-position-variable②">3.5.5. Find an exact match with context</a>
+    <li><a href="#ref-for-string-position-variable①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-string-position-variable②">(2)</a> <a href="#ref-for-string-position-variable③">(3)</a>
+    <li><a href="#ref-for-string-position-variable④">3.5.3. Word Boundaries</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-remove">
    <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-remove">3.5.3. Parse a text directive</a> <a href="#ref-for-list-remove①">(2)</a>
+    <li><a href="#ref-for-list-remove">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-list-remove①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-size">
    <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-size">3.5.3. Parse a text directive</a> <a href="#ref-for-list-size①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-skip-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">https://infra.spec.whatwg.org/#skip-ascii-whitespace</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-skip-ascii-whitespace">3.5.5. Find an exact match with context</a> <a href="#ref-for-skip-ascii-whitespace①">(2)</a> <a href="#ref-for-skip-ascii-whitespace②">(3)</a> <a href="#ref-for-skip-ascii-whitespace③">(4)</a>
+    <li><a href="#ref-for-list-size">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-split-on-commas">
    <a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-split-on-commas">3.5.3. Parse a text directive</a>
+    <li><a href="#ref-for-split-on-commas">3.3.1. Parsing the fragment directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-strictly-split">
    <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-strictly-split">3.5.2. Find text matches</a>
+    <li><a href="#ref-for-strictly-split">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-string">
    <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string">3.5.2. Find text matches</a> <a href="#ref-for-string①">(2)</a> <a href="#ref-for-string②">(3)</a>
-    <li><a href="#ref-for-string③">3.5.4. Find a matching Range</a>
+    <li><a href="#ref-for-string">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-string①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a> <a href="#ref-for-string④">(4)</a> <a href="#ref-for-string⑤">(5)</a>
+    <li><a href="#ref-for-string⑥">3.5.3. Word Boundaries</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-struct">
    <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-struct">3.5.3. Parse a text directive</a> <a href="#ref-for-struct①">(2)</a>
+    <li><a href="#ref-for-struct">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-struct①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
@@ -2822,6 +3332,31 @@ match based on whether the element-id was scrolled.</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
+    <a data-link-type="biblio">[css-cascade-4]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-computed-value" style="color:initial">computed value</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[css-display-3]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-propdef-display" style="color:initial">display</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[css-flexbox-1]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-propdef-flex" style="color:initial">flex</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[css-grid-1]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-propdef-grid" style="color:initial">grid</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[CSS2]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-propdef-visibility" style="color:initial">visibility</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[cssom-view-1]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-dictdef-scrollintoviewoptions" style="color:initial">ScrollIntoViewOptions</span>
@@ -2834,14 +3369,31 @@ match based on whether the element-id was scrolled.</p>
      <li><span class="dfn-paneled" id="term-for-document" style="color:initial">Document</span>
      <li><span class="dfn-paneled" id="term-for-dom-node-element_node" style="color:initial">ELEMENT_NODE</span>
      <li><span class="dfn-paneled" id="term-for-element" style="color:initial">Element</span>
+     <li><span class="dfn-paneled" id="term-for-node" style="color:initial">Node</span>
      <li><span class="dfn-paneled" id="term-for-range" style="color:initial">Range</span>
-     <li><span class="dfn-paneled" id="term-for-treewalker" style="color:initial">TreeWalker</span>
+     <li><span class="dfn-paneled" id="term-for-text" style="color:initial">Text</span>
+     <li><span class="dfn-paneled" id="term-for-concept-range-bp" style="color:initial">boundary point</span>
+     <li><span class="dfn-paneled" id="term-for-range-collapsed" style="color:initial">collapsed</span>
      <li><span class="dfn-paneled" id="term-for-dom-range-commonancestorcontainer" style="color:initial">commonAncestorContainer</span>
-     <li><span class="dfn-paneled" id="term-for-dom-document-createtreewalker" style="color:initial">createTreeWalker(root)</span>
+     <li><span class="dfn-paneled" id="term-for-concept-cd-data" style="color:initial">data</span>
      <li><span class="dfn-paneled" id="term-for-concept-document" style="color:initial">document</span>
-     <li><span class="dfn-paneled" id="term-for-dom-treewalker-nextnode" style="color:initial">nextNode()</span>
+     <li><span class="dfn-paneled" id="term-for-document-element" style="color:initial">document element</span>
+     <li><span class="dfn-paneled" id="term-for-concept-range-end" style="color:initial">end</span>
+     <li><span class="dfn-paneled" id="term-for-concept-range-end-node" style="color:initial">end node</span>
+     <li><span class="dfn-paneled" id="term-for-concept-range-end-offset" style="color:initial">end offset</span>
+     <li><span class="dfn-paneled" id="term-for-concept-tree-following" style="color:initial">following</span>
+     <li><span class="dfn-paneled" id="term-for-concept-element-local-name" style="color:initial">local name</span>
+     <li><span class="dfn-paneled" id="term-for-boundary-point-node" style="color:initial">node</span>
+     <li><span class="dfn-paneled" id="term-for-concept-node-document" style="color:initial">node document</span>
      <li><span class="dfn-paneled" id="term-for-dom-node-nodetype" style="color:initial">nodeType</span>
+     <li><span class="dfn-paneled" id="term-for-concept-tree-parent" style="color:initial">parent</span>
      <li><span class="dfn-paneled" id="term-for-dom-node-parentnode" style="color:initial">parentNode</span>
+     <li><span class="dfn-paneled" id="term-for-concept-shadow-including-descendant" style="color:initial">shadow-including descendant</span>
+     <li><span class="dfn-paneled" id="term-for-concept-shadow-including-tree-order" style="color:initial">shadow-including tree order</span>
+     <li><span class="dfn-paneled" id="term-for-concept-range-start" style="color:initial">start</span>
+     <li><span class="dfn-paneled" id="term-for-concept-range-start-node" style="color:initial">start node</span>
+     <li><span class="dfn-paneled" id="term-for-concept-range-start-offset" style="color:initial">start offset</span>
+     <li><span class="dfn-paneled" id="term-for-concept-cd-substring" style="color:initial">substring data</span>
      <li><span class="dfn-paneled" id="term-for-concept-document-url" style="color:initial">url</span>
     </ul>
    <li>
@@ -2858,10 +3410,23 @@ match based on whether the element-id was scrolled.</p>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
+     <li><span class="dfn-paneled" id="term-for-htmlaudioelement" style="color:initial">HTMLAudioElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlelement" style="color:initial">HTMLElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmliframeelement" style="color:initial">HTMLIFrameElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlimageelement" style="color:initial">HTMLImageElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlmeterelement" style="color:initial">HTMLMeterElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlobjectelement" style="color:initial">HTMLObjectElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlprogresselement" style="color:initial">HTMLProgressElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlscriptelement" style="color:initial">HTMLScriptElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlselectelement" style="color:initial">HTMLSelectElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlstyleelement" style="color:initial">HTMLStyleElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlvideoelement" style="color:initial">HTMLVideoElement</span>
+     <li><span class="dfn-paneled" id="term-for-being-rendered" style="color:initial">being rendered</span>
      <li><span class="dfn-paneled" id="term-for-browsing-context" style="color:initial">browsing context</span>
      <li><span class="dfn-paneled" id="term-for-browsing-context-set" style="color:initial">browsing context set</span>
      <li><span class="dfn-paneled" id="term-for-language" style="color:initial">language</span>
      <li><span class="dfn-paneled" id="term-for-latest-entry" style="color:initial">latest entry</span>
+     <li><span class="dfn-paneled" id="term-for-dom-select-multiple" style="color:initial">multiple</span>
      <li><span class="dfn-paneled" id="term-for-scroll-to-the-fragment-identifier" style="color:initial">scroll to the fragment</span>
      <li><span class="dfn-paneled" id="term-for-session-history" style="color:initial">session history</span>
      <li><span class="dfn-paneled" id="term-for-the-indicated-part-of-the-document" style="color:initial">the indicated part of the document</span>
@@ -2871,12 +3436,16 @@ match based on whether the element-id was scrolled.</p>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-list-append" style="color:initial">append</span>
+     <li><span class="dfn-paneled" id="term-for-assert" style="color:initial">assert</span>
+     <li><span class="dfn-paneled" id="term-for-iteration-break" style="color:initial">break</span>
+     <li><span class="dfn-paneled" id="term-for-code-point" style="color:initial">code point</span>
+     <li><span class="dfn-paneled" id="term-for-string-concatenate" style="color:initial">concatenate</span>
+     <li><span class="dfn-paneled" id="term-for-iteration-continue" style="color:initial">continue</span>
      <li><span class="dfn-paneled" id="term-for-string-length" style="color:initial">length</span>
      <li><span class="dfn-paneled" id="term-for-list" style="color:initial">list</span>
      <li><span class="dfn-paneled" id="term-for-string-position-variable" style="color:initial">position variable</span>
      <li><span class="dfn-paneled" id="term-for-list-remove" style="color:initial">remove</span>
      <li><span class="dfn-paneled" id="term-for-list-size" style="color:initial">size</span>
-     <li><span class="dfn-paneled" id="term-for-skip-ascii-whitespace" style="color:initial">skip ascii whitespace</span>
      <li><span class="dfn-paneled" id="term-for-split-on-commas" style="color:initial">split on commas</span>
      <li><span class="dfn-paneled" id="term-for-strictly-split" style="color:initial">strictly split a string</span>
      <li><span class="dfn-paneled" id="term-for-string" style="color:initial">string</span>
@@ -2892,6 +3461,16 @@ match based on whether the element-id was scrolled.</p>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-css-cascade-4">[CSS-CASCADE-4]
+   <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-4/">CSS Cascading and Inheritance Level 4</a>. 28 August 2018. CR. URL: <a href="https://www.w3.org/TR/css-cascade-4/">https://www.w3.org/TR/css-cascade-4/</a>
+   <dt id="biblio-css-display-3">[CSS-DISPLAY-3]
+   <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-display-3/">CSS Display Module Level 3</a>. 11 July 2019. CR. URL: <a href="https://www.w3.org/TR/css-display-3/">https://www.w3.org/TR/css-display-3/</a>
+   <dt id="biblio-css-flexbox-1">[CSS-FLEXBOX-1]
+   <dd>Tab Atkins Jr.; et al. <a href="https://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Layout Module Level 1</a>. 19 November 2018. CR. URL: <a href="https://www.w3.org/TR/css-flexbox-1/">https://www.w3.org/TR/css-flexbox-1/</a>
+   <dt id="biblio-css-grid-1">[CSS-GRID-1]
+   <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="https://www.w3.org/TR/css-grid-1/">CSS Grid Layout Module Level 1</a>. 14 December 2017. CR. URL: <a href="https://www.w3.org/TR/css-grid-1/">https://www.w3.org/TR/css-grid-1/</a>
+   <dt id="biblio-css2">[CSS2]
+   <dd>Bert Bos; et al. <a href="https://www.w3.org/TR/CSS2/">Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/CSS2/">https://www.w3.org/TR/CSS2/</a>
    <dt id="biblio-cssom-view-1">[CSSOM-VIEW-1]
    <dd>Simon Pieters. <a href="https://www.w3.org/TR/cssom-view-1/">CSSOM View Module</a>. 17 March 2016. WD. URL: <a href="https://www.w3.org/TR/cssom-view-1/">https://www.w3.org/TR/cssom-view-1/</a>
    <dt id="biblio-dom">[DOM]
@@ -2934,11 +3513,17 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-fragment-directive-delimiter">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter①">(2)</a> <a href="#ref-for-fragment-directive-delimiter②">(3)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="parse-a-text-directive">
+   <b><a href="#parse-a-text-directive">#parse-a-text-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-parse-a-text-directive">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="fragmentdirective">
    <b><a href="#fragmentdirective">#fragmentdirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentdirective">3.3.2. Fragment directive grammar</a> <a href="#ref-for-fragmentdirective②">(2)</a>
-    <li><a href="#ref-for-fragmentdirective③">3.5.2. Find text matches</a>
+    <li><a href="#ref-for-fragmentdirective③">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="unknowndirective">
@@ -2963,8 +3548,9 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="textdirective">
    <b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirective">3.3.2. Fragment directive grammar</a> <a href="#ref-for-textdirective①">(2)</a>
-    <li><a href="#ref-for-textdirective②">3.5.2. Find text matches</a>
+    <li><a href="#ref-for-textdirective">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-textdirective①">3.3.2. Fragment directive grammar</a> <a href="#ref-for-textdirective②">(2)</a>
+    <li><a href="#ref-for-textdirective③">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveparameters">
@@ -3015,10 +3601,77 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-scroll-a-range-into-view">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-locale">
-   <b><a href="#current-locale">#current-locale</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="process-a-fragment-directive">
+   <b><a href="#process-a-fragment-directive">#process-a-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-locale">3.5.5. Find an exact match with context</a> <a href="#ref-for-current-locale①">(2)</a> <a href="#ref-for-current-locale②">(3)</a> <a href="#ref-for-current-locale③">(4)</a>
+    <li><a href="#ref-for-process-a-fragment-directive">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-process-a-fragment-directive①">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="find-range-from-a-text-directive">
+   <b><a href="#find-range-from-a-text-directive">#find-range-from-a-text-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-find-range-from-a-text-directive">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="next-non-whitespace-position">
+   <b><a href="#next-non-whitespace-position">#next-non-whitespace-position</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-next-non-whitespace-position">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-next-non-whitespace-position①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="find-a-string-in-range">
+   <b><a href="#find-a-string-in-range">#find-a-string-in-range</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-find-a-string-in-range">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-find-a-string-in-range①">(2)</a> <a href="#ref-for-find-a-string-in-range②">(3)</a> <a href="#ref-for-find-a-string-in-range③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="search-invisible">
+   <b><a href="#search-invisible">#search-invisible</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-search-invisible">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-search-invisible①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="non-searchable-subtree">
+   <b><a href="#non-searchable-subtree">#non-searchable-subtree</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-non-searchable-subtree">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-non-searchable-subtree①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="visible-text-node">
+   <b><a href="#visible-text-node">#visible-text-node</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-visible-text-node">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-visible-text-node①">(2)</a> <a href="#ref-for-visible-text-node②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="has-block-level-display">
+   <b><a href="#has-block-level-display">#has-block-level-display</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-has-block-level-display">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-has-block-level-display①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="nearest-block-ancestor">
+   <b><a href="#nearest-block-ancestor">#nearest-block-ancestor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-nearest-block-ancestor">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="find-a-range-from-a-node-list">
+   <b><a href="#find-a-range-from-a-node-list">#find-a-range-from-a-node-list</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-find-a-range-from-a-node-list">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="get-boundary-point-at-index">
+   <b><a href="#get-boundary-point-at-index">#get-boundary-point-at-index</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-get-boundary-point-at-index">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-get-boundary-point-at-index①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="word-bounded">
+   <b><a href="#word-bounded">#word-bounded</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-word-bounded">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-word-bounded①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fragmentdirective①">

--- a/index.html
+++ b/index.html
@@ -1470,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-28">28 February 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-03-04">4 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2138,6 +2138,27 @@ text=bar,baz
     <p><var>prefix</var> and <var>suffix</var> are both optional, either or both may be omitted, in
   which case context on that side of a match is not checked. e.g. If <var>prefix</var> is null, text is matched without any requirement on what text precedes it.</p>
    </div>
+   <div class="note" role="note">
+     While the matching text and its prefix/suffix can span across
+  block-boundaries, the individual parameters to these steps cannot. That is,
+  each of <var>prefix</var>, <var>textStart</var>, <var>textEnd</var>, and <var>suffix</var> will only match text
+  within a single block. 
+    <div class="example" id="example-73638554">
+     <a class="self-link" href="#example-73638554"></a> 
+<pre>:~:text=The quick,lazy dog</pre>
+      will fail to match in 
+<pre>    &lt;div>The&lt;div> &lt;/div>quick brown fox&lt;/div>
+    &lt;div>jumped over the lazy dog&lt;/div>
+</pre>
+     <p>because the starting string "The quick" does not appear within a single,
+    uninterrupted block. The instance of "The quick" in the document has a
+    block element between "The" and "quick".</p>
+     <p>It does, however, match in this example:</p>
+<pre>    &lt;div>The quick brown fox&lt;/div>
+    &lt;div>jumped over the lazy dog&lt;/div>
+</pre>
+    </div>
+   </div>
    <ol>
     <li data-md>
      <p>Let <var>searchRange</var> be a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#range" id="ref-for-range①②">Range</a></code> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start">start</a> (<var>document</var>, 0) and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end">end</a> (<var>document</var>, <var>document</var>’s <a data-link-type="dfn">length</a>)</p>
@@ -2281,7 +2302,9 @@ non-whitespace position</dfn> follow the steps:</p>
       &lt;/div>
 </pre>
     <p></p>
-    <p>Will perform a search on "abc", then on "c", then on "e".</p>
+    <p>Will perform a search on "abc", then on "d", then on "e".</p>
+    <p>Thus, <var>query</var> will only match text that is continuous (i.e. uninterrupted by
+  a block-level container) within a single block-level container.</p>
    </div>
    <ol>
     <li data-md>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 4, 2020, 7:53 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbokand%2FScrollToTextFragment%2Fba36a8334e9a9f300f87050235c4cd764fcfcce7%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
FATAL ERROR: Line 238 isn't indented enough (needs 1 indent) to be valid Markdown:
"   input| starting at index 5."
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/ScrollToTextFragment%2392.)._
</details>
