### PR TITLE
Fix the "this version" self-link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Status: CG-DRAFT
 Title: Text Fragments
-ED: wicg.github.io/ScrollToTextFragment/index.html
+ED: https://wicg.github.io/ScrollToTextFragment/
 Shortname: text-fragments
 Level: 1
 Editor: Nick Burris, Google https://www.google.com, nburris@chromium.org


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/ScrollToTextFragment/pull/105.html" title="Last updated on May 27, 2020, 10:51 AM UTC (3b48319)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ScrollToTextFragment/105/24f616a...foolip:3b48319.html" title="Last updated on May 27, 2020, 10:51 AM UTC (3b48319)">Diff</a>